### PR TITLE
Make smart_fractions and prime symbols play nice together

### DIFF
--- a/php-typography/class-php-typography.php
+++ b/php-typography/class-php-typography.php
@@ -552,6 +552,8 @@ class PHP_Typography {
 		$this->components['hyphensArray'] = array_unique( array( '-', $this->chr['hyphen'] ) );
 		$this->components['hyphens']      = implode( '|', $this->components['hyphensArray'] );
 
+		$this->components['numbersPrime'] = '\b(?:\d+\/)?\d{1,3}';
+
 		/*
 		 // \p{Lu} equals upper case letters and should match non english characters; since PHP 4.4.0 and 5.1.0
 		 // for more info, see http://www.regextester.com/pregsyntax.html#regexp.reference.unicode
@@ -754,12 +756,14 @@ class PHP_Typography {
 
 		$this->regex['smartQuotesSingleQuotedNumbers']       = "/(?<=\W|\A)'(\d+)'(?=\W|\Z)/u";
 		$this->regex['smartQuotesDoubleQuotedNumbers']       = '/(?<=\W|\A)"(\d+)"(?=\W|\Z)/u';
-		$this->regex['smartQuotesDoublePrime']               = "/(\b\d{1,3})''(?=\W|\Z)/u";
-		$this->regex['smartQuotesDoublePrimeCompound']       = "/(\b\d{1,3})''(?=-\w)/u";
-		$this->regex['smartQuotesDoublePrime1GlyphCompound'] = "/(\b\d{1,3})\"(?=-\w)/u";
-		$this->regex['smartQuotesSinglePrimeCompound']       = "/(\b\d{1,3})'(?=-\w)/u";
-		$this->regex['smartQuotesSingleDoublePrime']         = "/(\b\d{1,3})'(\s*)(\b\d+)''(?=\W|\Z)/u";
-		$this->regex['smartQuotesSingleDoublePrime1Glyph']   = "/(\b\d{1,3})'(\s*)(\b\d+)\"(?=\W|\Z)/u";
+		$this->regex['smartQuotesDoublePrime']               = "/({$this->components['numbersPrime']})''(?=\W|\Z)/u";
+		$this->regex['smartQuotesDoublePrimeCompound']       = "/({$this->components['numbersPrime']})''(?=-\w)/u";
+		$this->regex['smartQuotesDoublePrime1Glyph']         = "/({$this->components['numbersPrime']})\"(?=\W|\Z)/u";
+		$this->regex['smartQuotesDoublePrime1GlyphCompound'] = "/({$this->components['numbersPrime']})\"(?=-\w)/u";
+		$this->regex['smartQuotesSinglePrime']               = "/({$this->components['numbersPrime']})'(?=\W|\Z)/u";
+		$this->regex['smartQuotesSinglePrimeCompound']       = "/({$this->components['numbersPrime']})'(?=-\w)/u";
+		$this->regex['smartQuotesSingleDoublePrime']         = "/({$this->components['numbersPrime']})'(\s*)(\b(?:\d+\/)?\d+)''(?=\W|\Z)/u";
+		$this->regex['smartQuotesSingleDoublePrime1Glyph']   = "/({$this->components['numbersPrime']})'(\s*)(\b(?:\d+\/)?\d+)\"(?=\W|\Z)/u";
 		$this->regex['smartQuotesCommaQuote']                = '/(?<=\s|\A),(?=\S)/';
 		$this->regex['smartQuotesApostropheWords']           = "/(?<=[\w|{$this->components['nonEnglishWordCharacters']}])'(?=[\w|{$this->components['nonEnglishWordCharacters']}])/u";
 		$this->regex['smartQuotesApostropheDecades']         = "/'(\d\d\b)/";
@@ -1000,7 +1004,8 @@ class PHP_Typography {
 			(?:\s?\/\s?{$this->chr['zeroWidthSpace']}?)	# strip out any zero-width spaces inserted by wrap_hard_hyphens
 			(\d+)
 			(
-				(?:\<sup\>(?:st|nd|rd|th)<\/sup\>)?	# handle ordinals after fractions
+				(?:{$this->chr['singlePrime']}|{$this->chr['doublePrime']})? # handle fractions followed by prime symbols
+				(?:\<sup\>(?:st|nd|rd|th)<\/sup\>)?	                         # handle ordinals after fractions
 				(?:\Z|\s|{$this->chr['noBreakSpace']}|{$this->chr['noBreakNarrowSpace']}|\.|\!|\?|\)|\;|\:|\'|\")	# makes sure we are not messing up a url
 			)
 			/xu";
@@ -2318,8 +2323,10 @@ class PHP_Typography {
 		$textnode->data = preg_replace( $this->regex['smartQuotesSingleDoublePrime'],         '$1' . $this->chr['singlePrime'] . '$2$3' . $this->chr['doublePrime'], $textnode->data );
 		$textnode->data = preg_replace( $this->regex['smartQuotesSingleDoublePrime1Glyph'],   '$1' . $this->chr['singlePrime'] . '$2$3' . $this->chr['doublePrime'], $textnode->data );
 		$textnode->data = preg_replace( $this->regex['smartQuotesDoublePrime'],               '$1' . $this->chr['doublePrime'],                                      $textnode->data ); // should not interfere with regular quote matching.
+		$textnode->data = preg_replace( $this->regex['smartQuotesSinglePrime'],               '$1' . $this->chr['singlePrime'],                                      $textnode->data );
 		$textnode->data = preg_replace( $this->regex['smartQuotesSinglePrimeCompound'],       '$1' . $this->chr['singlePrime'],                                      $textnode->data );
 		$textnode->data = preg_replace( $this->regex['smartQuotesDoublePrimeCompound'],       '$1' . $this->chr['doublePrime'],                                      $textnode->data );
+		$textnode->data = preg_replace( $this->regex['smartQuotesDoublePrime1Glyph'],         '$1' . $this->chr['doublePrime'],                                      $textnode->data ); // should not interfere with regular quote matching.
 		$textnode->data = preg_replace( $this->regex['smartQuotesDoublePrime1GlyphCompound'], '$1' . $this->chr['doublePrime'],                                      $textnode->data );
 
 		// Backticks.

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -1538,6 +1538,9 @@ class PHP_Typography_Test extends PHPUnit_Framework_TestCase
     		array( " 6'' ",                             ' 6&Prime; ' ), // nobody uses this for quotes, so it should be OK to keep the primes here
      		array( 'ein 32"-Fernseher',                 'ein 32&Prime;-Fernseher' ),
     		array( "der 8'-Ölbohrer",                   "der 8&prime;-&Ouml;lbohrer" ),
+    		array( "der 1/4'-Bohrer",                   "der 1/4&prime;-Bohrer" ),
+    		array( "2/4'",                              "2/4&prime;" ),
+    		array( '3/44"',                             '3/44&Prime;' ),
     		array( '("Some" word',					    '(&ldquo;Some&rdquo; word' ),
     	);
     }
@@ -1936,7 +1939,36 @@ class PHP_Typography_Test extends PHPUnit_Framework_TestCase
     	$typo->set_smart_fractions( false );
     	$typo->set_fraction_spacing( false );
 
-    	$this->assertSame( $input, clean_html( $typo->process( $input ) ) );
+    	$this->assertSame( clean_html( $input ), clean_html( $typo->process( $input ) ) );
+    }
+
+    public function provide_smart_fractions_smart_quotes_data() {
+    	return array(
+    		array(
+    			'1/2" 1/2\' 3/4″',
+    			'<sup class="num">1</sup>&frasl;<sub class="denom">2</sub>&Prime; <sup class="num">1</sup>&frasl;<sub class="denom">2</sub>&prime; <sup class="num">3</sup>&frasl;<sub class="denom">4</sub>&Prime;',
+    			'num',
+    			'denom'
+    		),
+    	);
+    }
+
+    /**
+     * @covers ::smart_fractions
+     *
+     * @uses PHP_Typography\Parse_Text
+     *
+     * @dataProvider provide_smart_fractions_smart_quotes_data
+     */
+    public function test_smart_fractions_with_smart_quotes( $input, $result, $num_css_class, $denom_css_class )
+    {
+    	$typo = new PHP_Typography_CSS_Classes( false, 'now', array( 'numerator' => $num_css_class, 'denominator' => $denom_css_class) );
+    	$typo->set_smart_fractions( true );
+    	$typo->set_smart_quotes( true );
+    	$typo->set_true_no_break_narrow_space( true );
+    	$typo->set_fraction_spacing( false );
+
+    	$this->assertSame( $result, clean_html( $typo->process( $input ) ) );
     }
 
     public function provide_fraction_spacing_data() {


### PR DESCRIPTION
- [x] Straight quotes (" and ') are replaced with prime symbols (&Prime; and &prime;) after fractions: <br>`1/2"` is transformed into `1/2&Prime;`
- [x] Fractions are styled nicely when they are followed by prime symbols:<br>`1/2″` is transformed into `<span class="num">2</span>&frasl;<span class="denom"></span>&Prime;`
