### PR TITLE
Various fixes

### DIFF
--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -461,7 +461,9 @@ class WP_Typography {
 
 		foreach ( $title_parts as $index => $part ) {
 			// Remove "&shy;" and "&#8203;" after processing title part.
-			$title_parts[ $index ] = strip_tags( str_replace( array( \PHP_Typography\uchr( 173 ), \PHP_Typography\uchr( 8203 ) ), '', $this->process( $part, true, true, $settings ) ) );
+			$title_parts[ $index ] = strip_tags(
+				str_replace( [ \PHP_Typography\Strings::uchr( 173 ), \PHP_Typography\Strings::uchr( 8203 ) ], '', $this->process( $part, true, true, $settings ) )
+			);
 		}
 
 		return $title_parts;

--- a/php-typography/bin/class-pattern-converter.php
+++ b/php-typography/bin/class-pattern-converter.php
@@ -75,7 +75,7 @@ class Pattern_Converter {
 	 */
 	function get_sequence( $pattern ) {
 		$characters = Strings::mb_str_split( str_replace( '.', '_', $pattern ) );
-		$result = array();
+		$result = [];
 
 		foreach ( $characters as $index => $chr ) {
 			if ( ctype_digit( $chr ) ) {
@@ -117,7 +117,7 @@ class Pattern_Converter {
 	 * @param array $comments An array of TeX comments.
 	 */
 	function write_results( array $patterns, array $exceptions, array $comments ) {
-		$pattern_mapping = array();
+		$pattern_mapping = [];
 
 		foreach ( $patterns as $pattern ) {
 			$segment = $this->get_segment( $pattern );
@@ -128,18 +128,18 @@ class Pattern_Converter {
 		}
 
 		// Produce a nice exceptions mapping.
-		$json_exceptions = array();
+		$json_exceptions = [];
 		foreach ( $exceptions as $exception ) {
 			$json_exceptions[ mb_strtolower( str_replace( '-', '', $exception ) ) ] = mb_strtolower( $exception );
 		}
 
-		$json_results = array(
+		$json_results = [
 			'language'         => $this->language,
 			'source_url'       => $this->url,
 			'copyright'        => array_map( 'rtrim', $comments ),
 			'exceptions'       => $json_exceptions,
 			'patterns'         => $pattern_mapping,
-		);
+		];
 
 		echo json_encode( $json_results, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
 	}
@@ -154,23 +154,21 @@ class Pattern_Converter {
 		$this->url      = $url;
 		$this->language = $language;
 
-		$this->word_characters = join(
-			array(
-				"\w.'ʼ᾽ʼ᾿’",
-				Strings::uchr( 8205, 8204, 768, 769, 771, 772, 775, 776, 784, 803, 805, 814, 817 ),
-				'\p{Devanagari}' . Strings::uchr( 2385, 2386 ),
-				'\p{Bengali}',
-				'\p{Gujarati}',
-				'\p{Gurmukhi}',
-				'\p{Kannada}',
-				'\p{Oriya}',
-				'\p{Tamil}',
-				'\p{Telugu}',
-				'\p{Malayalam}',
-				'\p{Thai}',
-				'-',
-			)
-		);
+		$this->word_characters = join( [
+			"\w.'ʼ᾽ʼ᾿’",
+			Strings::uchr( 8205, 8204, 768, 769, 771, 772, 775, 776, 784, 803, 805, 814, 817 ),
+			'\p{Devanagari}' . Strings::uchr( 2385, 2386 ),
+			'\p{Bengali}',
+			'\p{Gujarati}',
+			'\p{Gurmukhi}',
+			'\p{Kannada}',
+			'\p{Oriya}',
+			'\p{Tamil}',
+			'\p{Telugu}',
+			'\p{Malayalam}',
+			'\p{Thai}',
+			'-',
+		] );
 	}
 
 	/**
@@ -255,9 +253,9 @@ class Pattern_Converter {
 		}
 
 		// Results.
-		$comments   = array();
-		$patterns   = array();
-		$exceptions = array();
+		$comments   = [];
+		$patterns   = [];
+		$exceptions = [];
 
 		// Status indicators.
 		$reading_patterns   = false;

--- a/php-typography/bin/pattern2json.php
+++ b/php-typography/bin/pattern2json.php
@@ -35,7 +35,7 @@ define( 'WP_TYPOGRAPHY_DEBUG', true );
 require_once dirname( __DIR__ ) . '/php-typography-autoload.php';
 
 $shortopts = 'l:f:hv';
-$longopts = array( 'lang:', 'file:', 'help', 'version' );
+$longopts = [ 'lang:', 'file:', 'help', 'version' ];
 
 $options = getopt( $shortopts, $longopts );
 

--- a/php-typography/class-dom.php
+++ b/php-typography/class-dom.php
@@ -32,7 +32,7 @@ namespace PHP_Typography;
  *
  * @since 4.2.0
  */
-class DOM {
+abstract class DOM {
 
 	/**
 	 * Converts \DOMNodeList to array;

--- a/php-typography/class-settings.php
+++ b/php-typography/class-settings.php
@@ -727,7 +727,7 @@ class Settings implements \ArrayAccess {
 	 * Update smartQuotesBrackets component after quote style change.
 	 */
 	private function update_smart_quotes_brackets() {
-		$this->components['smartQuotesBrackets'] = array(
+		$this->components['smartQuotesBrackets'] = [
 			// Single quotes.
 			"['"  => '[' . $this->chr['singleQuoteOpen'],
 			"{'"  => '{' . $this->chr['singleQuoteOpen'],
@@ -747,7 +747,7 @@ class Settings implements \ArrayAccess {
 			// Quotes & quotes.
 			"\"'" => $this->chr['doubleQuoteOpen'] . $this->chr['singleQuoteOpen'],
 			"'\"" => $this->chr['singleQuoteClose'] . $this->chr['doubleQuoteClose'],
-		);
+		];
 		$this->components['smartQuotesBracketMatches']      = array_keys( $this->components['smartQuotesBrackets'] );
 		$this->components['smartQuotesBracketReplacements'] = array_values( $this->components['smartQuotesBrackets'] );
 	}

--- a/php-typography/class-strings.php
+++ b/php-typography/class-strings.php
@@ -30,7 +30,7 @@ namespace PHP_Typography;
 /**
  * A utility class to handle fast and save string function access.
  */
-class Strings {
+abstract class Strings {
 	/**
 	 * An array of encodings in detection order.
 	 *


### PR DESCRIPTION
* Use `\PHP_Typography\Strings::uchr` from the WordPress side, too.
* Make `\PHP_Typography\Strings` and `\PHP_Typography\DOM` abstract classes.
* Fix a few missed `array()` declarations.