### PR TITLE
Fix tests for updated German pattern file.

### DIFF
--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -249,8 +249,10 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 	public function provide_hyphenate_data() {
 		return [
 			[ 'A few words to hyphenate like KINGdesk Really there should be more hyphenation here', 'A few words to hy|phen|ate like KING|desk Re|al|ly there should be more hy|phen|ation here', 'en-US', true ], // fake tokenizer doesn't split off punctuation.
-			[ 'Sauerstofffeldflasche', 'Sau|er|stoff|feld|fla|sche', 'de', true ],
-			[ 'Sauerstoff Feldflasche', 'Sau|er|stoff Feld|fla|sche', 'de', true ], // Compound words would not be hyphenated separately.
+			// Not working with newer de pattern file: [ 'Sauerstofffeldflasche', 'Sau|er|stoff|feld|fla|sche', 'de', true ],.
+			[ 'Sauerstofffeldflasche', 'Sauer|stoff|feld|fla|sche', 'de', true ],
+			// Not working with newer de pattern file: [ 'Sauerstoff Feldflasche', 'Sau|er|stoff Feld|fla|sche', 'de', true ],.
+			[ 'Sauerstoff Feldflasche', 'Sauer|stoff Feld|fla|sche', 'de', true ], // Compound words would not be hyphenated separately.
 			[ 'Sauerstoff-Feldflasche', 'Sauerstoff-Feldflasche', 'de', false ],
 			[ 'A', 'A', 'de', true ],
 			[ 'table', 'ta|ble', 'en-US', false ],

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -3772,8 +3772,10 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 	public function provide_hyphenate_data() {
 		return [
 			[ 'A few words to hyphenate, like KINGdesk. Really, there should be more hyphenation here!', 'A few words to hy&shy;phen&shy;ate, like KING&shy;desk. Re&shy;al&shy;ly, there should be more hy&shy;phen&shy;ation here!', 'en-US', true, true, true, false ],
-			[ 'Sauerstofffeldflasche', 'Sau&shy;er&shy;stoff&shy;feld&shy;fla&shy;sche', 'de', true, true, true, false ],
-			[ 'Sauerstoff-Feldflasche', 'Sau&shy;er&shy;stoff-Feld&shy;fla&shy;sche', 'de', true, true, true, true ],
+			// Not working with new de pattern file: [ 'Sauerstofffeldflasche', 'Sau&shy;er&shy;stoff&shy;feld&shy;fla&shy;sche', 'de', true, true, true, false ],.
+			[ 'Sauerstofffeldflasche', 'Sauer&shy;stoff&shy;feld&shy;fla&shy;sche', 'de', true, true, true, false ],
+			// Not working with new de pattern file: [ 'Sauerstoff-Feldflasche', 'Sau&shy;er&shy;stoff-Feld&shy;fla&shy;sche', 'de', true, true, true, true ],.
+			[ 'Sauerstoff-Feldflasche', 'Sauer&shy;stoff-Feld&shy;fla&shy;sche', 'de', true, true, true, true ],
 			[ 'Sauerstoff-Feldflasche', 'Sauerstoff-Feldflasche', 'de', true, true, true, false ],
 			[ 'Geschäftsübernahme', 'Ge&shy;sch&auml;fts&shy;&uuml;ber&shy;nah&shy;me', 'de', true, true, true, false ],
 			[ 'Trinkwasserinstallation', 'Trink&shy;was&shy;ser&shy;in&shy;stal&shy;la&shy;ti&shy;on', 'de', true, true, true, false ],


### PR DESCRIPTION
With the new pattern file, "Sauerstoff" is now hyphenated "Sauer|stoff" (before a9de79ba4817ff0a9d25ea961c703a25bafd7930: "Sau|er|stoff"). 

Not sure if that is intentional by the upstream pattern maintainers.