### PR TITLE
Update PHP-Typography to 5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
     "require": {
         "php": ">=5.6.0",
-        "mundschenk-at/php-typography": "master-dev",
+        "mundschenk-at/php-typography": "^5.2.0",
         "level-2/dice": "^2.0.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -116,16 +116,16 @@
         },
         {
             "name": "mundschenk-at/php-typography",
-            "version": "v5.2.0",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mundschenk-at/php-typography.git",
-                "reference": "fb64a62b869344bdeb752c65e6e0afb498efe924"
+                "reference": "68568a7c570ce902b65d40a0509295a13b54885f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mundschenk-at/php-typography/zipball/fb64a62b869344bdeb752c65e6e0afb498efe924",
-                "reference": "fb64a62b869344bdeb752c65e6e0afb498efe924",
+                "url": "https://api.github.com/repos/mundschenk-at/php-typography/zipball/68568a7c570ce902b65d40a0509295a13b54885f",
+                "reference": "68568a7c570ce902b65d40a0509295a13b54885f",
                 "shasum": ""
             },
             "require": {
@@ -173,7 +173,7 @@
                 }
             ],
             "description": "A PHP library for improving your web typography",
-            "time": "2017-09-30T11:17:16+00:00"
+            "time": "2017-10-27T18:33:56+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f62daacd08641bec2e1694e300156c0c",
+    "content-hash": "80ef5dc43ad4e6aedf8cc3b99f2512b7",
     "packages": [
         {
             "name": "level-2/dice",
@@ -116,7 +116,7 @@
         },
         {
             "name": "mundschenk-at/php-typography",
-            "version": "dev-master",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mundschenk-at/php-typography.git",
@@ -3003,7 +3003,6 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "mundschenk-at/php-typography": 20,
         "wp-coding-standards/wpcs": 20,
         "brain/monkey": 20,
         "antecedent/patchwork": 20

--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -739,6 +739,7 @@ class WP_Typography {
 			$s->set_smart_diacritics( false );
 		}
 
+		// Space control.
 		$s->set_single_character_word_spacing( $config[ Config::SINGLE_CHARACTER_WORD_SPACING ] );
 		$s->set_dash_spacing( $config[ Config::DASH_SPACING ] );
 		$s->set_fraction_spacing( $config[ Config::FRACTION_SPACING ] );
@@ -750,10 +751,27 @@ class WP_Typography {
 		$s->set_dewidow( $config[ Config::PREVENT_WIDOWS ] );
 		$s->set_max_dewidow_length( $config[ Config::WIDOW_MIN_LENGTH ] );
 		$s->set_max_dewidow_pull( $config[ Config::WIDOW_MAX_PULL ] );
+
+		/**
+		 * Filters whether to use the NARROW NO-BREAK SPACE character (U+202F, &#8239;)
+		 * where appropriate.
+		 *
+		 * Historically, browser and/or font support for this character has been limited,
+		 * so by default it is replaced by the normal (non-narrow) NO-BREAK SPACE (U+00A0, &nbsp;).
+		 *
+		 * @since 5.1.0
+		 *
+		 * @param bool $enable Default false.
+		 */
+		$s->set_true_no_break_narrow_space( apply_filters( 'typo_narrow_no_break_space', false ) );
+
+		// Line wrapping.
 		$s->set_wrap_hard_hyphens( $config[ Config::WRAP_HYPHENS ] );
 		$s->set_email_wrap( $config[ Config::WRAP_EMAILS ] );
 		$s->set_url_wrap( $config[ Config::WRAP_URLS ] );
 		$s->set_min_after_url_wrap( $config[ Config::WRAP_MIN_AFTER ] );
+
+		// CSS hooks.
 		$s->set_style_ampersands( $config[ Config::STYLE_AMPS ] );
 		$s->set_style_caps( $config[ Config::STYLE_CAPS ] );
 		$s->set_style_numbers( $config[ Config::STYLE_NUMBERS ] );

--- a/tests/class-wp-typography-test.php
+++ b/tests/class-wp-typography-test.php
@@ -366,6 +366,8 @@ class WP_Typography_Test extends TestCase {
 		] );
 
 		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
 
 		$s = $this->wp_typo->get_settings();
 
@@ -382,7 +384,7 @@ class WP_Typography_Test extends TestCase {
 	 * @uses ::init_settings_from_options
 	 * @uses ::maybe_fix_object
 	 */
-	public function test_get_settings_off() {
+	public function test_get_settings_hyphenation_off() {
 
 		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
 			Config::IGNORE_TAGS                    => [ 'script' ],
@@ -433,11 +435,13 @@ class WP_Typography_Test extends TestCase {
 			Config::HYPHENATE_MIN_LENGTH           => 2,
 			Config::HYPHENATE_MIN_BEFORE           => 2,
 			Config::HYPHENATE_MIN_AFTER            => 2,
-			Config::HYPHENATE_EXCEPTIONS         => [],
+			Config::HYPHENATE_EXCEPTIONS           => [],
 			Config::IGNORE_PARSER_ERRORS           => false,
 		] );
 
 		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
 
 		$s = $this->wp_typo->get_settings();
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update PHP-Typography to 5.2.0.
- Provide access to the "use true narrow space" setting.
