### PR TITLE
Extract common component

### DIFF
--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -125,13 +125,6 @@ class WP_Typography {
 	private $default_settings;
 
 	/**
-	 * The multlingual support object.
-	 *
-	 * @var Multilingual_Support
-	 */
-	private $multilingual;
-
-	/**
 	 * The plugin components in order of execution.
 	 *
 	 * @var Plugin_Component[]
@@ -173,15 +166,14 @@ class WP_Typography {
 		// Initialize activation/deactivation handler.
 		$this->plugin_components[] = $setup;
 
+		// Initialize multilingual support.
+		$this->plugin_components[] = $multi;
+
 		// Initialize public interface handler.
 		$this->plugin_components[] = $public_if;
 
 		// Initialize admin interface handler.
 		$this->plugin_components[] = $admin;
-
-		// Initialize multilingual support.
-		$this->multilingual        = $multi;
-		$this->plugin_components[] = $this->multilingual;
 	}
 
 	/**
@@ -424,14 +416,6 @@ class WP_Typography {
 		// Clear cache if necessary.
 		if ( $this->options->get( Options::CLEAR_CACHE ) ) {  // any truthy value will do.
 			$this->clear_cache();
-		}
-
-		// Load settings.
-		$config = $this->get_config();
-
-		// Enable multilingual support.
-		if ( $config[ Config::ENABLE_MULTILINGUAL_SUPPORT ] ) {
-			add_filter( 'typo_settings', [ $this->multilingual, 'automatic_language_settings' ] );
 		}
 	}
 
@@ -843,7 +827,14 @@ class WP_Typography {
 	 */
 	public function get_default_options() {
 		if ( empty( $this->default_settings ) ) {
-			$this->default_settings = $this->multilingual->filter_defaults( wp_list_pluck( Config::get_defaults(), 'default' ) );
+			/**
+			 * Filters the default settings used to initialize the plugin.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @param array $defaults The default settings indexed by their configuration key.
+			 */
+			$this->default_settings = apply_filters( 'typo_plugin_defaults', wp_list_pluck( Config::get_defaults(), 'default' ) );
 		}
 
 		return $this->default_settings;

--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -30,6 +30,7 @@ use \WP_Typography\Data_Storage\Options;
 use \WP_Typography\Data_Storage\Transients;
 
 use \WP_Typography\Components\Admin_Interface;
+use \WP_Typography\Components\Common;
 use \WP_Typography\Components\Multilingual_Support;
 use \WP_Typography\Components\Plugin_Component;
 use \WP_Typography\Components\Public_Interface;
@@ -145,6 +146,7 @@ class WP_Typography {
 	 *
 	 * @param string               $version     The full plugin version string (e.g. "3.0.0-beta.2").
 	 * @param Setup                $setup       Required.
+	 * @param Common               $common      Required.
 	 * @param Admin_Interface      $admin       Required.
 	 * @param Public_Interface     $public_if   Required.
 	 * @param Multilingual_Support $multi       Required.
@@ -152,7 +154,7 @@ class WP_Typography {
 	 * @param Cache                $cache       Required.
 	 * @param Options              $options     Required.
 	 */
-	public function __construct( $version, Setup $setup, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi, Transients $transients, Cache $cache, Options $options ) {
+	public function __construct( $version, Setup $setup, Common $common, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi, Transients $transients, Cache $cache, Options $options ) {
 		// Basic set-up.
 		$this->version = $version;
 
@@ -165,6 +167,9 @@ class WP_Typography {
 
 		// Initialize activation/deactivation handler.
 		$this->plugin_components[] = $setup;
+
+		// Initialize common component.
+		$this->plugin_components[] = $common;
 
 		// Initialize multilingual support.
 		$this->plugin_components[] = $multi;
@@ -182,9 +187,6 @@ class WP_Typography {
 	public function run() {
 		// Set plugin singleton.
 		self::set_instance( $this );
-
-		// Load settings.
-		add_action( 'init', [ $this, 'init' ] );
 
 		// Run all the plugin components.
 		foreach ( $this->plugin_components as $component ) {
@@ -401,22 +403,6 @@ class WP_Typography {
 	 */
 	public static function filter_feed_title( $text, Settings $settings = null ) {
 		return self::get_instance()->process_feed( $text, true, $settings );
-	}
-
-	/**
-	 * Loads the settings from the option table.
-	 */
-	public function init() {
-
-		// Restore defaults if necessary.
-		if ( $this->options->get( Options::RESTORE_DEFAULTS ) ) {  // any truthy value will do.
-			$this->set_default_options( true );
-		}
-
-		// Clear cache if necessary.
-		if ( $this->options->get( Options::CLEAR_CACHE ) ) {  // any truthy value will do.
-			$this->clear_cache();
-		}
 	}
 
 	/**
@@ -834,7 +820,7 @@ class WP_Typography {
 			 *
 			 * @param array $defaults The default settings indexed by their configuration key.
 			 */
-			$this->default_settings = apply_filters( 'typo_plugin_defaults', wp_list_pluck( Config::get_defaults(), 'default' ) );
+			$this->default_settings = (array) apply_filters( 'typo_plugin_defaults', wp_list_pluck( Config::get_defaults(), 'default' ) );
 		}
 
 		return $this->default_settings;

--- a/includes/wp-typography/components/class-common.php
+++ b/includes/wp-typography/components/class-common.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2017 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Components;
+
+use \WP_Typography\Data_Storage\Options;
+use \WP_Typography\Settings\Plugin_Configuration as Config;
+
+/**
+ * Common functionality necessary for both public and admin interfaces.
+ *
+ * @since 5.1.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Common implements Plugin_Component {
+
+	/**
+	 * The plugin object.
+	 *
+	 * @var      \WP_Typography $plugin The main plugin class instance.
+	 */
+	private $plugin;
+
+	/**
+	 * An abstraction of the WordPress Options API.
+	 *
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * Create a new instace of WP_Typography\Setup.
+	 *
+	 * @param Options $options     The Options API handler.
+	 */
+	public function __construct( Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Registers the de-/activation/uninstall hooks for the plugin.
+	 *
+	 * @param \WP_Typography $plugin The plugin instance.
+	 */
+	public function run( \WP_Typography $plugin ) {
+		$this->plugin = $plugin;
+
+		// Load settings.
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+
+	/**
+	 * Restore default options or clear cache if requested.
+	 */
+	public function init() {
+
+		// Restore defaults if necessary.
+		if ( $this->options->get( Options::RESTORE_DEFAULTS ) ) {  // any truthy value will do.
+			$this->plugin->set_default_options( true );
+		}
+
+		// Clear cache if necessary.
+		if ( $this->options->get( Options::CLEAR_CACHE ) ) {  // any truthy value will do.
+			$this->plugin->clear_cache();
+		}
+	}
+}

--- a/includes/wp-typography/ui/class-control.php
+++ b/includes/wp-typography/ui/class-control.php
@@ -148,7 +148,10 @@ abstract class Control {
 		'span'   => [ 'class' => [] ],
 		'input'  => self::ALLOWED_INPUT_ATTRIBUTES,
 		'select' => self::ALLOWED_INPUT_ATTRIBUTES,
-		'option' => [ 'value' => [] ],
+		'option' => [
+			'value'    => [],
+			'selected' => [],
+		],
 		'code'   => [],
 		'strong' => [],
 		'em'     => [],

--- a/tests/class-wp-typography-singleton-test.php
+++ b/tests/class-wp-typography-singleton-test.php
@@ -77,11 +77,12 @@ class WP_Typography_Singleton_Test extends TestCase {
 	 * @uses ::get_version_hash
 	 * @uses ::hash_version_string
 	 * @uses \WP_Typography\Components\Admin_Interface::__construct
+	 * @uses \WP_Typography\Components\Public_Interface::__construct
+	 * @uses \WP_Typography\Components\Setup::__construct
+	 * @uses \WP_Typography\Components\Common::__construct
 	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
 	 * @uses \WP_Typography\Data_Storage\Cache::__construct
-	 * @uses \WP_Typography\Components\Public_Interface::__construct
 	 * @uses \WP_Typography\Data_Storage\Options::__construct
-	 * @uses \WP_Typography\Components\Setup::__construct
 	 * @uses \WP_Typography\Data_Storage\Transients::__construct
 	 */
 	public function test_singleton() {
@@ -97,6 +98,11 @@ class WP_Typography_Singleton_Test extends TestCase {
 
 		// Mock WP_Typography\Components\Setup instance.
 		$setup = m::mock( \WP_Typography\Components\Setup::class, [ '/some/path', $options ] )
+			->shouldReceive( 'run' )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Components\Common instance.
+		$common = m::mock( \WP_Typography\Components\Common::class, [ $options ] )
 			->shouldReceive( 'run' )->byDefault()
 			->getMock();
 
@@ -123,7 +129,7 @@ class WP_Typography_Singleton_Test extends TestCase {
 		$public_if = m::mock( Public_Interface::class, [ 'plugin_basename' ] );
 		$public_if->shouldReceive( 'run' )->byDefault();
 
-		$typo = new \WP_Typography( '6.6.6', $setup, $admin, $public_if, $multi, $transients, $cache, $options );
+		$typo = new \WP_Typography( '6.6.6', $setup, $common, $admin, $public_if, $multi, $transients, $cache, $options );
 		$typo->run();
 
 		$typo2 = \WP_Typography::get_instance();
@@ -187,11 +193,16 @@ class WP_Typography_Singleton_Test extends TestCase {
 		$multi = m::mock( \WP_Typography\Components\Multilingual_Support::class );
 		$multi->shouldReceive( 'run' );
 
+		// Mock WP_Typography\Components\Common instance.
+		$common = m::mock( \WP_Typography\Components\Common::class )
+			->shouldReceive( 'run' )->byDefault()
+			->getMock();
+
 		$transients = m::mock( \WP_Typography\Data_Storage\Transients::class );
 		$cache      = m::mock( \WP_Typography\Data_Storage\Cache::class );
 		$options    = m::mock( \WP_Typography\Data_Storage\Options::class );
 
-		$typo = new \WP_Typography( '6.6.6', $setup, $admin, $public_if, $multi, $transients, $cache, $options );
+		$typo = new \WP_Typography( '6.6.6', $setup, $common, $admin, $public_if, $multi, $transients, $cache, $options );
 		$typo->run();
 		$typo->run();
 	}

--- a/tests/components/class-common-test.php
+++ b/tests/components/class-common-test.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2017 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or ( at your option ) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  @package mundschenk-at/wp-typography/tests
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests\Components;
+
+use WP_Typography\Components\Common;
+use WP_Typography\Data_Storage\Options;
+use WP_Typography\Settings\Plugin_Configuration as Config;
+
+use WP_Typography\Tests\TestCase;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+/**
+ * Common component unit test.
+ *
+ * @coversDefaultClass \WP_Typography\Components\Common
+ * @usesDefaultClass \WP_Typography\Components\Common
+ *
+ * @uses ::__construct
+ * @uses ::run
+ */
+class Common_Test extends TestCase {
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var Common
+	 */
+	protected $common;
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var \WP_Typography\Data_Storage\Options
+	 */
+	protected $options;
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var WP_Typography
+	 */
+	protected $plugin;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() { // @codingStandardsIgnoreLine
+		parent::setUp();
+
+		// Mock WP_Typography\Data_Storage\Options instance.
+		$this->options = m::mock( \WP_Typography\Data_Storage\Options::class )
+			->shouldReceive( 'get' )->andReturn( false )->byDefault()
+			->shouldReceive( 'set' )->andReturn( false )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Components\Common instance.
+		$this->common = m::mock( Common::class, [ $this->options ] )
+			->shouldAllowMockingProtectedMethods()->makePartial();
+
+		$this->plugin = m::mock( \WP_Typography::class )->shouldReceive( 'get_version' )->andReturn( '6.6.6' )->byDefault()->getMock();
+
+		// Finish setup.
+		$this->common->run( $this->plugin );
+	}
+
+	/**
+	 * Necesssary clean-up work.
+	 */
+	protected function tearDown() { // @codingStandardsIgnoreLine
+		parent::tearDown();
+	}
+
+	/**
+	 * Test constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$common = m::mock( Common::class, [ $this->options ] );
+
+		$this->assertAttributeSame( $this->options, 'options', $common );
+	}
+
+
+	/**
+	 * Test run.
+	 *
+	 * @covers ::run
+	 */
+	public function test_run() {
+		Actions\expectAdded( 'init' )->with( [ $this->common, 'init' ] )->once();
+
+		$this->common->run( $this->plugin );
+
+		$this->assertAttributeSame( $this->plugin, 'plugin', $this->common );
+	}
+
+	/**
+	 * Provide data for testing add_content_filters.
+	 *
+	 * @return array
+	 */
+	public function provide_init_data() {
+		return [
+			[ true, true ],
+			[ false, false ],
+			[ true, false ],
+			[ false, true ],
+		];
+	}
+
+	/**
+	 * Test init
+	 *
+	 * @covers ::init
+	 *
+	 * @dataProvider provide_init_data
+	 *
+	 * @param bool $restore_defaults The typo_restore_defaults value.
+	 * @param bool $clear_cache      The typo_clear_cache value.
+	 */
+	public function test_init( $restore_defaults, $clear_cache ) {
+		$this->options->shouldReceive( 'get' )->once()->with( Options::RESTORE_DEFAULTS )->andReturn( $restore_defaults );
+		$this->options->shouldReceive( 'get' )->once()->with( Options::CLEAR_CACHE )->andReturn( $clear_cache );
+
+		if ( $restore_defaults ) {
+			$this->plugin->shouldReceive( 'set_default_options' )->once()->with( true );
+		}
+
+		if ( $clear_cache ) {
+			$this->plugin->shouldReceive( 'clear_cache' )->once();
+		}
+
+		$this->assertNull( $this->common->init() );
+	}
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Extract `init` action common to both admin and public interfaces to new component `Common`.
- Adapt unit tests accordingly.
