### PR TITLE
Delete RESTORE_DEFAULTS and CLEAR_CACHE options instead of setting them to false

### DIFF
--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -772,8 +772,8 @@ class WP_Typography {
 
 		if ( $force_defaults ) {
 			// Push the reset switch.
-			$this->options->set( Options::RESTORE_DEFAULTS, false );
-			$this->options->set( Options::CLEAR_CACHE, false );
+			$this->options->delete( Options::RESTORE_DEFAULTS );
+			$this->options->delete( Options::CLEAR_CACHE );
 		}
 	}
 
@@ -804,7 +804,7 @@ class WP_Typography {
 		$this->transients->invalidate();
 		$this->cache->invalidate();
 
-		$this->options->set( Options::CLEAR_CACHE, false );
+		$this->options->delete( Options::CLEAR_CACHE );
 	}
 
 	/**

--- a/tests/class-wp-typography-test.php
+++ b/tests/class-wp-typography-test.php
@@ -811,8 +811,8 @@ class WP_Typography_Test extends TestCase {
 
 		$this->options->shouldNotReceive( 'get' )->with( Options::RESTORE_DEFAULTS );
 		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
-		$this->options->shouldReceive( 'set' )->once()->with( Options::RESTORE_DEFAULTS, false )->andReturn( true );
-		$this->options->shouldReceive( 'set' )->once()->with( Options::CLEAR_CACHE, false )->andReturn( true );
+		$this->options->shouldReceive( 'delete' )->once()->with( Options::RESTORE_DEFAULTS )->andReturn( true );
+		$this->options->shouldReceive( 'delete' )->once()->with( Options::CLEAR_CACHE )->andReturn( true );
 
 		$this->wp_typo->set_default_options( true );
 		$this->assertTrue( true );
@@ -849,7 +849,7 @@ class WP_Typography_Test extends TestCase {
 		$this->transients->shouldReceive( 'invalidate' );
 		$this->cache->shouldReceive( 'invalidate' );
 
-		$this->options->shouldReceive( 'set' )->once()->with( 'clear_cache', false )->andReturn( true );
+		$this->options->shouldReceive( 'delete' )->once()->with( 'clear_cache' )->andReturn( true );
 
 		$this->wp_typo->clear_cache();
 		$this->assertTrue( true );

--- a/tests/components/class-admin-interface-test.php
+++ b/tests/components/class-admin-interface-test.php
@@ -404,7 +404,7 @@ class Admin_Interface_Test extends TestCase {
 		Functions\expect( 'add_settings_error' )->once()->with( Admin_Interface::OPTION_GROUP . 'my-tab', 'some-id', 'An important message.', 'notice-info' );
 
 		// Do it.
-		$this->assertSame( $input, $this->admin->trigger_admin_notice( 'setting', 'some-id', 'An important message.', 'notice-info', $input ) );
+		$this->assertSame( (bool) $input, $this->admin->trigger_admin_notice( 'setting', 'some-id', 'An important message.', 'notice-info', $input ) );
 	}
 
 	/**


### PR DESCRIPTION
Changes proposed in this pull request:
- Delete the helper options `RESTORE_DEFAULTS` and `CLEAR_CACHE` instead of setting them to `false`.
- Prevent duplicate admin notices (https://core.trac.wordpress.org/ticket/21989).