### PR TITLE
Split WP_Typography between API facade, API implementation and Plugin Controller

### DIFF
--- a/includes/class-wp-typography-factory.php
+++ b/includes/class-wp-typography-factory.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2018 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -71,6 +71,13 @@ abstract class WP_Typography_Factory {
 			] );
 			self::$factory->addRule( Options::class, [
 				'shared' => true,
+			] );
+
+			// API implementation.
+			self::$factory->addRule( 'substitutions', [
+				\WP_Typography::class => [
+					'instance' => \WP_Typography\Implementation::class,
+				],
 			] );
 
 			// Load version from plugin data.

--- a/includes/class-wp-typography-factory.php
+++ b/includes/class-wp-typography-factory.php
@@ -31,7 +31,6 @@ use WP_Typography\Data_Storage\Options;
 use WP_Typography\Data_Storage\Transients;
 
 use WP_Typography\Components\Admin_Interface;
-use WP_Typography\Components\Multilingual_Support;
 use WP_Typography\Components\Public_Interface;
 use WP_Typography\Components\Setup;
 

--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2014-2017 Peter Putzer.
+ *  Copyright 2014-2018 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or
@@ -28,13 +28,6 @@
 use WP_Typography\Data_Storage\Cache;
 use WP_Typography\Data_Storage\Options;
 use WP_Typography\Data_Storage\Transients;
-
-use WP_Typography\Components\Admin_Interface;
-use WP_Typography\Components\Common;
-use WP_Typography\Components\Multilingual_Support;
-use WP_Typography\Components\Plugin_Component;
-use WP_Typography\Components\Public_Interface;
-use WP_Typography\Components\Setup;
 
 use WP_Typography\Settings\Plugin_Configuration as Config;
 
@@ -133,13 +126,6 @@ class WP_Typography {
 	private $default_settings;
 
 	/**
-	 * The plugin components in order of execution.
-	 *
-	 * @var Plugin_Component[]
-	 */
-	private $plugin_components = [];
-
-	/**
 	 * The singleton instance.
 	 *
 	 * @var WP_Typography
@@ -151,17 +137,12 @@ class WP_Typography {
 	 *
 	 * @since 5.1.0 Optional parameters $transients, $cache, $options, $setup, $public_if added.
 	 *
-	 * @param string               $version     The full plugin version string (e.g. "3.0.0-beta.2").
-	 * @param Setup                $setup       Required.
-	 * @param Common               $common      Required.
-	 * @param Admin_Interface      $admin       Required.
-	 * @param Public_Interface     $public_if   Required.
-	 * @param Multilingual_Support $multi       Required.
-	 * @param Transients           $transients  Required.
-	 * @param Cache                $cache       Required.
-	 * @param Options              $options     Required.
+	 * @param string     $version     The full plugin version string (e.g. "3.0.0-beta.2").
+	 * @param Transients $transients  Required.
+	 * @param Cache      $cache       Required.
+	 * @param Options    $options     Required.
 	 */
-	public function __construct( $version, Setup $setup, Common $common, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi, Transients $transients, Cache $cache, Options $options ) {
+	public function __construct( $version, Transients $transients, Cache $cache, Options $options ) {
 		// Basic set-up.
 		$this->version = $version;
 
@@ -171,38 +152,12 @@ class WP_Typography {
 
 		// Initialize Options API handler.
 		$this->options = $options;
-
-		// Initialize activation/deactivation handler.
-		$this->plugin_components[] = $setup;
-
-		// Initialize common component.
-		$this->plugin_components[] = $common;
-
-		// Initialize multilingual support.
-		$this->plugin_components[] = $multi;
-
-		// Initialize public interface handler.
-		$this->plugin_components[] = $public_if;
-
-		// Initialize admin interface handler.
-		$this->plugin_components[] = $admin;
-	}
-
-	/**
-	 * Starts the plugin for real.
-	 */
-	public function run() {
-		// Set plugin singleton.
-		self::set_instance( $this );
-
-		// Run all the plugin components.
-		foreach ( $this->plugin_components as $component ) {
-			$component->run( $this );
-		}
 	}
 
 	/**
 	 * Retrieves (and if necessary creates) the WP_Typography instance. Should not be called outside of plugin set-up.
+	 *
+	 * @internal
 	 *
 	 * @since 5.0.0
 	 *
@@ -210,7 +165,7 @@ class WP_Typography {
 	 *
 	 * @throws BadMethodCallException Thrown when WP_Typography::set_instance after plugin initialization.
 	 */
-	private static function set_instance( WP_Typography $instance ) {
+	public static function set_instance( WP_Typography $instance ) {
 		if ( null === self::$_instance ) {
 			self::$_instance = $instance;
 		} else {

--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -39,91 +39,28 @@ use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;
  * Main wp-Typography plugin class. All WordPress specific code goes here.
  *
  * @api
+ *
+ * @method static string get_version() Retrieves the plugin version.
+ * @method string get_version() Retrieves the plugin version.
+ *
+ * @method Settings get_settings() Retrieves the internal Settings object for the preferences set via the plugin options screen.
+ *
+ * @method void clear_cache() Retrieves the plugin's default option values.
+ *
+ * @method array get_config() Retrieves the plugin configuration.
+ * @method array get_default_options() Retrieves the plugin's default option values.
+ * @method void set_default_options($force_defaults = false) Initializes the options with default values.
+ *
+ * @method string process(string $text, bool $is_title = false, bool $force_feed = false, Settings $settings = null) Processes a text fragment.
+ * @method string process_title($text, Settings $settings = null) Processes a heading text fragment.
+ * @method string process_feed_title($text, Settings $settings = null) Processes a heading text fragment as part of an RSS feed.
+ * @method string process_feed($text, $is_title = false, Settings $settings = null) Processes a content text fragment as part of an RSS feed.
+ * @method array process_title_parts($title_parts, Settings $settings = null) Processes title parts and strips &shy; and zero-width space.
+ *
+ * @method array get_hyphenation_languages() Retrieves and caches the list of valid hyphenation languages.
+ * @method array get_diacritic_languages() Retrieves and caches the list of valid diacritic replacement languages.
  */
-class WP_Typography {
-
-	/**
-	 * The full version string of the plugin.
-	 *
-	 * @var string $version
-	 */
-	private $version;
-
-	/**
-	 * A hash containing the various plugin settings.
-	 *
-	 * @var array
-	 */
-	private $config;
-
-	/**
-	 * The PHP_Typography instance doing the actual work.
-	 *
-	 * @var PHP_Typography
-	 */
-	private $typo;
-
-	/**
-	 * The PHP_Typography\Settings instance.
-	 *
-	 * @var Settings
-	 */
-	private $typo_settings;
-
-	/**
-	 * The Hyphenator_Cache instance.
-	 *
-	 * @var Hyphenator_Cache
-	 */
-	protected $hyphenator_cache;
-
-	/**
-	 * An abstraction of the WordPress transients API.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @var Transients
-	 */
-	private $transients;
-
-	/**
-	 * An abstraction of the WordPress object cache.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
-	 * An abstraction of the WordPress Options API.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @var Options
-	 */
-	private $options;
-
-	/**
-	 * The PHP_Typography configuration is not changed after initialization, so the settings hash can be cached.
-	 *
-	 * @var string The settings hash for the PHP_Typography instance
-	 */
-	private $cached_settings_hash;
-
-	/**
-	 * The body classes for the current request.
-	 *
-	 * @var string[]
-	 */
-	private $body_classes = [];
-
-	/**
-	 * An array of settings with their default value.
-	 *
-	 * @var array
-	 */
-	private $default_settings;
+abstract class WP_Typography {
 
 	/**
 	 * The singleton instance.
@@ -131,28 +68,6 @@ class WP_Typography {
 	 * @var WP_Typography
 	 */
 	private static $_instance;
-
-	/**
-	 * Sets up a new WP_Typography object.
-	 *
-	 * @since 5.1.0 Optional parameters $transients, $cache, $options, $setup, $public_if added.
-	 *
-	 * @param string     $version     The full plugin version string (e.g. "3.0.0-beta.2").
-	 * @param Transients $transients  Required.
-	 * @param Cache      $cache       Required.
-	 * @param Options    $options     Required.
-	 */
-	public function __construct( $version, Transients $transients, Cache $cache, Options $options ) {
-		// Basic set-up.
-		$this->version = $version;
-
-		// Initialize cache handlers.
-		$this->transients = $transients;
-		$this->cache      = $cache;
-
-		// Initialize Options API handler.
-		$this->options = $options;
-	}
 
 	/**
 	 * Retrieves (and if necessary creates) the WP_Typography instance. Should not be called outside of plugin set-up.
@@ -192,6 +107,25 @@ class WP_Typography {
 	}
 
 	/**
+	 * Allows API methods to be called statically, using the instance returned by
+	 * `WP_Typography::get_instance()`.
+	 *
+	 * @param  string $name      The method name.
+	 * @param  array  $arguments The method arguments.
+	 *
+	 * @throws BadMethodCallException Thrown when a non-existent method is called statically.
+	 *
+	 * @return mixed
+	 */
+	public static function __callStatic( $name, array $arguments ) {
+		if ( method_exists( self::$_instance, $name ) ) {
+			return self::$_instance->$name( ...$arguments );
+		} else {
+			throw new BadMethodCallException( "Static method WP_Typography::$name does not exist." );
+		}
+	}
+
+	/**
 	 * Retrieves a copy of the preferences set by the user via the plugin settings screen.
 	 *
 	 * @since 4.0.0
@@ -203,107 +137,11 @@ class WP_Typography {
 	}
 
 	/**
-	 * Retrieves the list of valid hyphenation languages.
-	 *
-	 * @since 4.0.0
-	 * @since 5.0.0 Language names are translated.
-	 *
-	 * @return string[] An array in the form of ( $language_code => $language ).
-	 */
-	public static function get_hyphenation_languages() {
-		return self::get_instance()->load_hyphenation_languages();
-	}
-
-	/**
-	 * Retrieves and caches the list of valid hyphenation languages.
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return string[] An array in the form of ( $language_code => $language ).
-	 */
-	public function load_hyphenation_languages() {
-		return $this->load_languages( 'hyphenate_languages', [ PHP_Typography::class, 'get_hyphenation_languages' ], 'hyphenate' );
-	}
-
-	/**
-	 * Retrieves the list of valid diacritic replacement languages.
-	 *
-	 * @since 4.0.0
-	 * @since 5.0.0 Language names are translated.
-	 *
-	 * @return string[] An array in the form of ( $language_code => $language ).
-	 */
-	public static function get_diacritic_languages() {
-		return self::get_instance()->load_diacritic_languages();
-	}
-
-	/**
-	 * Retrieves and caches the list of valid diacritic replacement languages.
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return string[] An array in the form of ( $language_code => $language ).
-	 */
-	public function load_diacritic_languages() {
-		return $this->load_languages( 'diacritic_languages', [ PHP_Typography::class, 'get_diacritic_languages' ], 'diacritic' );
-	}
-
-	/**
-	 * Load and cache given language list.
-	 *
-	 * @param  string   $cache_key         A cache key.
-	 * @param  callable $get_language_list Retrieval function for the language list.
-	 * @param  string   $type              Either 'diacritic' or 'hyphenate'.
-	 *
-	 * @return string[]
-	 */
-	protected function load_languages( $cache_key, callable $get_language_list, $type ) {
-		// Try to load hyphenation language list from cache.
-		$languages = $this->cache->get( $cache_key, $found );
-
-		// Dynamically generate the list of hyphenation language patterns.
-		if ( false === $found || ! is_array( $languages ) ) {
-			$languages = self::translate_languages( $get_language_list() );
-
-			/**
-			 * Filters the caching duration for the language plugin lists.
-			 *
-			 * @since 3.2.0
-			 *
-			 * @param number $duration The duration in seconds. Defaults to 1 week.
-			 * @param string $list     The name language plugin list.
-			 */
-			$duration = apply_filters( 'typo_language_list_caching_duration', WEEK_IN_SECONDS, "{$type}_languages" );
-
-			// Cache translated hyphenation languages.
-			$this->cache->set( $cache_key, $languages, $duration );
-		}
-
-		return $languages;
-	}
-
-	/**
-	 * Translate language list.
-	 *
-	 * @param string[] $languages An array in the form [ LANGUAGE_CODE => LANGUAGE ].
-	 *
-	 * @return string[] The same array with the language name translated.
-	 */
-	private static function translate_languages( array $languages ) {
-		array_walk( $languages, function( &$lang, $code ) {
-			$lang = _x( $lang, 'language name', 'wp-typography' );  // @codingStandardsIgnoreLine.
-		} );
-
-		// Re-sort after translation.
-		asort( $languages );
-
-		return $languages;
-	}
-
-	/**
 	 * Processes a content text fragment.
 	 *
 	 * @since 4.0.0
+	 *
+	 * @deprecated 5.3.0 Use `process` instead.
 	 *
 	 * @param string        $text     Required.
 	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
@@ -319,6 +157,8 @@ class WP_Typography {
 	 *
 	 * @since 4.0.0
 	 *
+	 * @deprecated 5.3.0 Use `process_title` instead.
+	 *
 	 * @param string        $text     Required.
 	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
 	 *
@@ -332,6 +172,8 @@ class WP_Typography {
 	 * Processes the title parts and strips &shy; and zero-width space.
 	 *
 	 * @since 4.0.0
+	 *
+	 * @deprecated 5.3.0 Use `process_title_parts` instead.
 	 *
 	 * @param array         $title_parts An array of strings.
 	 * @param Settings|null $settings    Optional. A settings object. Default null (which means the internal settings will be used).
@@ -347,6 +189,8 @@ class WP_Typography {
 	 *
 	 * @since 4.0.0
 	 *
+	 * @deprecated 5.3.0 Use `process_feed` instead.
+	 *
 	 * @param string        $text     Required.
 	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
 	 *
@@ -361,449 +205,15 @@ class WP_Typography {
 	 *
 	 * @since 4.0.0
 	 *
+	 * @deprecated 5.3.0 Use `process_feed_title` instead.
+	 *
 	 * @param string        $text     Required.
 	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
 	 *
 	 * @return string The processed $text.
 	 */
 	public static function filter_feed_title( $text, Settings $settings = null ) {
-		return self::get_instance()->process_feed( $text, true, $settings );
-	}
-
-	/**
-	 * Retrieves the plugin configuration.
-	 *
-	 * @return array
-	 */
-	public function get_config() {
-		if ( empty( $this->config ) ) {
-			$config = $this->options->get( Options::CONFIGURATION );
-			if ( is_array( $config ) ) {
-				$this->config = $config;
-			} else {
-				// The configuration array has been corrupted.
-				$this->set_default_options( true );
-			}
-		}
-
-		return $this->config;
-	}
-
-	/**
-	 * Retrieves the internal Settings object for the preferences set via the
-	 * plugin options screen.
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return Settings
-	 */
-	public function get_settings() {
-
-		// Initialize Settings instance.
-		if ( empty( $this->typo_settings ) ) {
-			$config    = $this->get_config();
-			$transient = 'php_settings_' . md5( wp_json_encode( $config ) );
-			$settings  = $this->transients->get_large_object( $transient );
-
-			if ( ! $settings instanceof Settings ) {
-				// OK, we have to initialize the PHP_Typography instance manually.
-				$settings = new Settings( false );
-
-				// Load our options into the Settings instance.
-				$this->init_settings_from_options( $settings, $config );
-
-				// Try again next time.
-				$this->transients->cache_object( $transient, $settings, 'settings' );
-			}
-
-			// Make parser errors filterable on an individual level.
-			$settings->set_parser_errors_handler( [ $this, 'parser_errors_handler' ] );
-
-			// Settings should be good now, so let's use them.
-			$this->typo_settings = $settings;
-
-			// Settings won't be touched again, so cache the hash.
-			$this->cached_settings_hash = $this->typo_settings->get_hash( 32, false );
-		}
-
-		return $this->typo_settings;
-	}
-
-	/**
-	 * Processes a heading text fragment.
-	 *
-	 * Calls `process( $text, true, $settings )`.
-	 *
-	 * @since 4.0.0 Parameter $settings added.
-	 *
-	 * @param string        $text Required.
-	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
-	 */
-	public function process_title( $text, Settings $settings = null ) {
-		return $this->process( $text, true, false, $settings );
-	}
-
-	/**
-	 * Processes a content text fragment as part of an RSS feed.
-	 *
-	 * Calls `process( $text, $is_title, true )`.
-	 *
-	 * @since 3.2.4
-	 * @since 4.0.0 Parameter $settings added.
-	 *
-	 * @param string        $text     Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
-	 */
-	public function process_feed( $text, $is_title = false, Settings $settings = null ) {
-		return $this->process( $text, $is_title, true, $settings );
-	}
-
-	/**
-	 * Processes title parts and strips &shy; and zero-width space.
-	 *
-	 * @since 3.2.5
-	 * @since 4.0.0 Parameter $settings added.
-	 *
-	 * @param array         $title_parts An array of strings.
-	 * @param Settings|null $settings    Optional. A settings object. Default null (which means the internal settings will be used).
-	 *
-	 * @return array
-	 */
-	public function process_title_parts( $title_parts, Settings $settings = null ) {
-		foreach ( $title_parts as $index => $part ) {
-			// Remove "&shy;" and "&#8203;" after processing title part.
-			$title_parts[ $index ] = strip_tags(
-				str_replace( [ \PHP_Typography\U::SOFT_HYPHEN, \PHP_Typography\U::ZERO_WIDTH_SPACE ], '', $this->process( $part, true, true, $settings ) )
-			);
-		}
-
-		return $title_parts;
-	}
-
-	/**
-	 * Processes a text fragment.
-	 *
-	 * @since 3.2.4 Parameter $force_feed added.
-	 * @since 4.0.0 Parameter $settings added.
-	 *
-	 * @param string        $text       Required.
-	 * @param bool          $is_title   Optional. Default false.
-	 * @param bool          $force_feed Optional. Default false.
-	 * @param Settings|null $settings   Optional. A settings object. Default null (which means the internal settings will be used).
-	 *
-	 * @return string The processed $text.
-	 */
-	public function process( $text, $is_title = false, $force_feed = false, Settings $settings = null ) {
-		// Use default settings if no argument was given.
-		if ( null === $settings ) {
-			$settings = $this->get_settings();
-			$hash     = $this->cached_settings_hash;
-		}
-
-		/**
-		 * Filters the settings object used for processing the text fragment.
-		 *
-		 * @since 5.0.0
-		 *
-		 * @param Settings $settings The settings instance.
-		 */
-		$settings = apply_filters( 'typo_settings', $settings );
-
-		// Caclulate hash if necessary.
-		$hash = isset( $hash ) ? $hash : $settings->get_hash( 32, false );
-
-		// Enable feed mode?
-		$feed = $force_feed || is_feed();
-
-		// Construct cache key.
-		$key = 'frag_' . md5( $text ) . '_' . $hash . '_' . ( $feed ? 'f' : '' ) . ( $is_title ? 't' : 's' );
-
-		// Retrieve cached text.
-		$found          = false;
-		$processed_text = $this->cache->get( $key, $found );
-
-		if ( empty( $found ) ) {
-			$typo = $this->get_typography_instance();
-
-			if ( $feed ) { // Feed readers are strange sometimes.
-				$processed_text = $typo->process_feed( $text, $settings, $is_title, $this->body_classes );
-			} else {
-				$processed_text = $typo->process( $text, $settings, $is_title, $this->body_classes );
-			}
-
-			/**
-			 * Filters the caching duration for processed text fragments.
-			 *
-			 * @since 3.2.0
-			 *
-			 * @param int $duration The duration in seconds. Defaults to 1 day.
-			 */
-			$duration = apply_filters( 'typo_processed_text_caching_duration', DAY_IN_SECONDS );
-
-			// Save text fragment for later.
-			$this->cache->set( $key, $processed_text, $duration );
-		}
-
-		return $processed_text;
-	}
-
-	/**
-	 * Grabs the body classes from the filter hook.
-	 *
-	 * @param  string[] $classes An array of CSS classes.
-	 *
-	 * @return string[]
-	 */
-	public function filter_body_class( array $classes ) {
-		$this->body_classes = $classes;
-
-		return $classes;
-	}
-
-	/**
-	 * Retrieves the PHP_Typography instance and ensure just-in-time initialization.
-	 */
-	protected function get_typography_instance() {
-
-		// Retrieve options.
-		$config = $this->get_config();
-
-		// Initialize PHP_Typography instance.
-		if ( empty( $this->typo ) ) {
-			$transient = 'php_' . md5( wp_json_encode( $config ) );
-			$typo      = $this->transients->get_large_object( $transient );
-
-			if ( ! $typo instanceof PHP_Typography ) {
-				// OK, we have to initialize the PHP_Typography instance manually.
-				$typo = new PHP_Typography();
-
-				// Ensure that all fixes are pre-initialized.
-				$typo->get_registry();
-
-				// Try again next time.
-				$this->transients->cache_object( $transient, $typo, 'typography' );
-			}
-
-			$this->typo = $typo;
-		}
-
-		// Also cache hyphenators (the pattern tries are expensive to build).
-		if ( $config[ Config::ENABLE_HYPHENATION ] && empty( $this->hyphenator_cache ) ) {
-			$transient        = 'php_hyphenator_cache';
-			$hyphenator_cache = $this->transients->get_large_object( $transient );
-
-			if ( ! $hyphenator_cache instanceof Hyphenator_Cache ) {
-				$hyphenator_cache = $this->typo->get_hyphenator_cache();
-
-				// Try again next time.
-				$this->transients->cache_object( $transient, $hyphenator_cache, 'hyphenator_cache' );
-			}
-
-			// Let's use it!
-			$this->hyphenator_cache = $hyphenator_cache;
-			$this->typo->set_hyphenator_cache( $this->hyphenator_cache );
-		}
-
-		return $this->typo;
-	}
-
-	/**
-	 * Save hyphenator cache for the next request.
-	 */
-	public function save_hyphenator_cache_on_shutdown() {
-		if ( ! empty( $this->hyphenator_cache ) && $this->hyphenator_cache->has_changed() ) {
-			$this->transients->cache_object( 'php_hyphenator_cache', $this->hyphenator_cache, 'hyphenator_cache' );
-		}
-	}
-
-	/**
-	 * Initializes the Settings object for PHP_Typography from the plugin options.
-	 *
-	 * @param Settings $s      The settings instance to initialize.
-	 * @param array    $config The array of configuration entries.
-	 */
-	protected function init_settings_from_options( Settings $s, array $config ) {
-		// Necessary for full Settings initialization.
-		$s->set_smart_dashes_style( $config[ Config::SMART_DASHES_STYLE ] );
-		$s->set_smart_quotes_primary( $config[ Config::SMART_QUOTES_PRIMARY ] );
-		$s->set_smart_quotes_secondary( $config[ Config::SMART_QUOTES_SECONDARY ] );
-
-		// Load the rest of the configuration variables into our Settings class.
-		$s->set_tags_to_ignore( $config[ Config::IGNORE_TAGS ] );
-		$s->set_classes_to_ignore( $config[ Config::IGNORE_CLASSES ] );
-		$s->set_ids_to_ignore( $config[ Config::IGNORE_IDS ] );
-
-		if ( $config[ Config::SMART_CHARACTERS ] ) {
-			$s->set_smart_dashes( $config[ Config::SMART_DASHES ] );
-			$s->set_smart_ellipses( $config[ Config::SMART_ELLIPSES ] );
-			$s->set_smart_math( $config[ Config::SMART_MATH ] );
-
-			// Note: smart_exponents was grouped with smart_math for the WordPress plugin,
-			// but does not have to be done that way for other ports.
-			$s->set_smart_exponents( $config[ Config::SMART_MATH ] );
-			$s->set_smart_fractions( $config[ Config::SMART_FRACTIONS ] );
-			$s->set_smart_ordinal_suffix( $config[ Config::SMART_ORDINALS ] );
-			$s->set_smart_marks( $config[ Config::SMART_MARKS ] );
-			$s->set_smart_quotes( $config[ Config::SMART_QUOTES ] );
-
-			$s->set_smart_diacritics( $config[ Config::SMART_DIACRITICS ] );
-			$s->set_diacritic_language( $config[ Config::DIACRITIC_LANGUAGES ] );
-			$s->set_diacritic_custom_replacements( $config[ Config::DIACRITIC_CUSTOM_REPLACEMENTS ] );
-		} else {
-			$s->set_smart_dashes( false );
-			$s->set_smart_ellipses( false );
-			$s->set_smart_math( false );
-			$s->set_smart_exponents( false );
-			$s->set_smart_fractions( false );
-			$s->set_smart_ordinal_suffix( false );
-			$s->set_smart_marks( false );
-			$s->set_smart_quotes( false );
-			$s->set_smart_diacritics( false );
-		}
-
-		// Space control.
-		$s->set_single_character_word_spacing( $config[ Config::SINGLE_CHARACTER_WORD_SPACING ] );
-		$s->set_dash_spacing( $config[ Config::DASH_SPACING ] );
-		$s->set_fraction_spacing( $config[ Config::FRACTION_SPACING ] );
-		$s->set_unit_spacing( $config[ Config::UNIT_SPACING ] );
-		$s->set_numbered_abbreviation_spacing( $config[ Config::NUMBERED_ABBREVIATIONS_SPACING ] );
-		$s->set_french_punctuation_spacing( $config[ Config::FRENCH_PUNCTUATION_SPACING ] );
-		$s->set_units( $config[ Config::UNITS ] );
-		$s->set_space_collapse( $config[ Config::SPACE_COLLAPSE ] );
-		$s->set_dewidow( $config[ Config::PREVENT_WIDOWS ] );
-		$s->set_max_dewidow_length( $config[ Config::WIDOW_MIN_LENGTH ] );
-		$s->set_max_dewidow_pull( $config[ Config::WIDOW_MAX_PULL ] );
-
-		/**
-		 * Filters whether to use the NARROW NO-BREAK SPACE character (U+202F, &#8239;)
-		 * where appropriate.
-		 *
-		 * Historically, browser and/or font support for this character has been limited,
-		 * so by default it is replaced by the normal (non-narrow) NO-BREAK SPACE (U+00A0, &nbsp;).
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param bool $enable Default false.
-		 */
-		$s->set_true_no_break_narrow_space( apply_filters( 'typo_narrow_no_break_space', false ) );
-
-		// Line wrapping.
-		$s->set_wrap_hard_hyphens( $config[ Config::WRAP_HYPHENS ] );
-		$s->set_email_wrap( $config[ Config::WRAP_EMAILS ] );
-		$s->set_url_wrap( $config[ Config::WRAP_URLS ] );
-		$s->set_min_after_url_wrap( $config[ Config::WRAP_MIN_AFTER ] );
-
-		// CSS hooks.
-		$s->set_style_ampersands( $config[ Config::STYLE_AMPS ] );
-		$s->set_style_caps( $config[ Config::STYLE_CAPS ] );
-		$s->set_style_numbers( $config[ Config::STYLE_NUMBERS ] );
-		$s->set_style_hanging_punctuation( $config[ Config::STYLE_HANGING_PUNCTUATION ] );
-		$s->set_style_initial_quotes( $config[ Config::STYLE_INITIAL_QUOTES ] );
-		$s->set_initial_quote_tags( $config[ Config::INITIAL_QUOTE_TAGS ] );
-
-		if ( $config[ Config::ENABLE_HYPHENATION ] ) {
-			$s->set_hyphenation( $config[ Config::ENABLE_HYPHENATION ] );
-			$s->set_hyphenate_headings( $config[ Config::HYPHENATE_HEADINGS ] );
-			$s->set_hyphenate_all_caps( $config[ Config::HYPHENATE_CAPS ] );
-			$s->set_hyphenate_title_case( $config[ Config::HYPHENATE_TITLE_CASE ] );
-			$s->set_hyphenate_compounds( $config[ Config::HYPHENATE_COMPOUNDS ] );
-			$s->set_hyphenation_language( $config[ Config::HYPHENATE_LANGUAGES ] );
-			$s->set_min_length_hyphenation( $config[ Config::HYPHENATE_MIN_LENGTH ] );
-			$s->set_min_before_hyphenation( $config[ Config::HYPHENATE_MIN_BEFORE ] );
-			$s->set_min_after_hyphenation( $config[ Config::HYPHENATE_MIN_AFTER ] );
-			$s->set_hyphenation_exceptions( $config[ Config::HYPHENATE_EXCEPTIONS ] );
-		} else { // save some cycles.
-			$s->set_hyphenation( $config[ Config::ENABLE_HYPHENATION ] );
-		}
-
-		/**
-		 * Filters whether HTML parser errors should be silently ignored.
-		 *
-		 * The resulting HTML will be a "best guess" by the parser, like it was before version 3.5.2.
-		 *
-		 * @since 3.6.0
-		 *
-		 * @param bool $ignore Default false.
-		 */
-		$s->set_ignore_parser_errors( $config[ Config::IGNORE_PARSER_ERRORS ] || apply_filters( 'typo_ignore_parser_errors', false ) );
-	}
-
-	/**
-	 * Initializes the options with default values.
-	 *
-	 * @param bool $force_defaults Optional. Default false.
-	 */
-	public function set_default_options( $force_defaults = false ) {
-		$update = $force_defaults;
-
-		// Grab configuration variables.
-		foreach ( $this->get_default_options() as $key => $default ) {
-			// Set or update the options with the default value if necessary.
-			if ( $force_defaults || ! isset( $this->config[ $key ] ) ) {
-				$this->config[ $key ] = $default;
-				$update               = true;
-			}
-		}
-
-		// Update stored options.
-		if ( $update ) {
-			$this->options->set( Options::CONFIGURATION, $this->config );
-		}
-
-		if ( $force_defaults ) {
-			// Push the reset switch.
-			$this->options->delete( Options::RESTORE_DEFAULTS );
-			$this->options->delete( Options::CLEAR_CACHE );
-		}
-	}
-
-	/**
-	 * Retrieves the plugin's default option values.
-	 *
-	 * @return array
-	 */
-	public function get_default_options() {
-		if ( empty( $this->default_settings ) ) {
-			/**
-			 * Filters the default settings used to initialize the plugin.
-			 *
-			 * @since 5.1.0
-			 *
-			 * @param array $defaults The default settings indexed by their configuration key.
-			 */
-			$this->default_settings = (array) apply_filters( 'typo_plugin_defaults', wp_list_pluck( Config::get_defaults(), 'default' ) );
-		}
-
-		return $this->default_settings;
-	}
-
-	/**
-	 * Clears all transients set by the plugin.
-	 */
-	public function clear_cache() {
-		$this->transients->invalidate();
-		$this->cache->invalidate();
-
-		$this->options->delete( Options::CLEAR_CACHE );
-	}
-
-	/**
-	 * Makes parser errors filterable.
-	 *
-	 * @param array $errors An array of error messages.
-	 *
-	 * @return array The filtered array.
-	 */
-	public function parser_errors_handler( $errors ) {
-		/**
-		 * Filters the HTML parser errors (if there are any).
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param array $errors An array of error messages.
-		 */
-		return apply_filters( 'typo_handle_parser_errors', $errors );
+		return self::get_instance()->process_feed_title( $text, $settings );
 	}
 
 	/**
@@ -823,7 +233,7 @@ class WP_Typography {
 	 *
 	 * @return string The hashed version (containing as few bytes as possible);
 	 */
-	private function hash_version_string( $version ) {
+	private static function hash_version_string( $version ) {
 		$hash = '';
 
 		foreach ( explode( '.', $version ) as $part ) {
@@ -834,15 +244,6 @@ class WP_Typography {
 	}
 
 	/**
-	 * Retrieves the plugin version.
-	 *
-	 * @return string
-	 */
-	public function get_version() {
-		return $this->version;
-	}
-
-	/**
 	 * Retrieves the plugin version hash.
 	 *
 	 * @deprecated 5.1.0
@@ -850,6 +251,6 @@ class WP_Typography {
 	 * @return string
 	 */
 	public function get_version_hash() {
-		return $this->hash_version_string( $this->version );
+		return self::hash_version_string( self::get_version() );
 	}
 }

--- a/includes/wp-typography/class-implementation.php
+++ b/includes/wp-typography/class-implementation.php
@@ -1,0 +1,691 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2014-2018 Peter Putzer.
+ *  Copyright 2009-2011 KINGdesk, LLC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography;
+
+use WP_Typography\Data_Storage\Cache;
+use WP_Typography\Data_Storage\Options;
+use WP_Typography\Data_Storage\Transients;
+
+use WP_Typography\Settings\Plugin_Configuration as Config;
+
+use PHP_Typography\PHP_Typography;
+use PHP_Typography\Settings;
+use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;
+
+/**
+ * Implementation behind the `WP_Typography` facade.
+ *
+ * @since 5.3.0
+ */
+class Implementation extends \WP_Typography {
+
+	/**
+	 * The full version string of the plugin.
+	 *
+	 * @var string $version
+	 */
+	private $version;
+
+	/**
+	 * A hash containing the various plugin settings.
+	 *
+	 * @var array
+	 */
+	private $config;
+
+	/**
+	 * The PHP_Typography instance doing the actual work.
+	 *
+	 * @var PHP_Typography
+	 */
+	private $typo;
+
+	/**
+	 * The PHP_Typography\Settings instance.
+	 *
+	 * @var Settings
+	 */
+	private $typo_settings;
+
+	/**
+	 * The Hyphenator_Cache instance.
+	 *
+	 * @var Hyphenator_Cache
+	 */
+	protected $hyphenator_cache;
+
+	/**
+	 * An abstraction of the WordPress transients API.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @var Transients
+	 */
+	private $transients;
+
+	/**
+	 * An abstraction of the WordPress object cache.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * An abstraction of the WordPress Options API.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * The PHP_Typography configuration is not changed after initialization, so the settings hash can be cached.
+	 *
+	 * @var string The settings hash for the PHP_Typography instance
+	 */
+	private $cached_settings_hash;
+
+	/**
+	 * The body classes for the current request.
+	 *
+	 * @var string[]
+	 */
+	private $body_classes = [];
+
+	/**
+	 * An array of settings with their default value.
+	 *
+	 * @var array
+	 */
+	private $default_settings;
+
+	/**
+	 * Sets up a new WP_Typography object.
+	 *
+	 * @since 5.1.0 Optional parameters $transients, $cache, $options, $setup, $public_if added.
+	 *
+	 * @param string     $version     The full plugin version string (e.g. "3.0.0-beta.2").
+	 * @param Transients $transients  Required.
+	 * @param Cache      $cache       Required.
+	 * @param Options    $options     Required.
+	 */
+	public function __construct( $version, Transients $transients, Cache $cache, Options $options ) {
+		// Basic set-up.
+		$this->version = $version;
+
+		// Initialize cache handlers.
+		$this->transients = $transients;
+		$this->cache      = $cache;
+
+		// Initialize Options API handler.
+		$this->options = $options;
+	}
+
+	/**
+	 * Retrieves and caches the list of valid hyphenation languages.
+	 *
+	 * @since 4.0.0
+	 * @since 5.0.0 Language names are translated.
+	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 *
+	 * @return string[] An array in the form of ( $language_code => $language ).
+	 */
+	public function get_hyphenation_languages() {
+		return $this->load_languages( 'hyphenate_languages', [ PHP_Typography::class, 'get_hyphenation_languages' ], 'hyphenate' );
+	}
+
+	/**
+	 * Retrieves and caches the list of valid diacritic replacement languages.
+	 *
+	 * @since 4.0.0
+	 * @since 5.0.0 Language names are translated.
+	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 *
+	 * @return string[] An array in the form of ( $language_code => $language ).
+	 */
+	public function get_diacritic_languages() {
+		return $this->load_languages( 'diacritic_languages', [ PHP_Typography::class, 'get_diacritic_languages' ], 'diacritic' );
+	}
+
+	/**
+	 * Load and cache given language list.
+	 *
+	 * @param  string   $cache_key         A cache key.
+	 * @param  callable $get_language_list Retrieval function for the language list.
+	 * @param  string   $type              Either 'diacritic' or 'hyphenate'.
+	 *
+	 * @return string[]
+	 */
+	protected function load_languages( $cache_key, callable $get_language_list, $type ) {
+		// Try to load hyphenation language list from cache.
+		$languages = $this->cache->get( $cache_key, $found );
+
+		// Dynamically generate the list of hyphenation language patterns.
+		if ( false === $found || ! is_array( $languages ) ) {
+			$languages = self::translate_languages( $get_language_list() );
+
+			/**
+			 * Filters the caching duration for the language plugin lists.
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param number $duration The duration in seconds. Defaults to 1 week.
+			 * @param string $list     The name language plugin list.
+			 */
+			$duration = apply_filters( 'typo_language_list_caching_duration', WEEK_IN_SECONDS, "{$type}_languages" );
+
+			// Cache translated hyphenation languages.
+			$this->cache->set( $cache_key, $languages, $duration );
+		}
+
+		return $languages;
+	}
+
+	/**
+	 * Translate language list.
+	 *
+	 * @param string[] $languages An array in the form [ LANGUAGE_CODE => LANGUAGE ].
+	 *
+	 * @return string[] The same array with the language name translated.
+	 */
+	private static function translate_languages( array $languages ) {
+		array_walk( $languages, function( &$lang, $code ) {
+			$lang = _x( $lang, 'language name', 'wp-typography' );  // @codingStandardsIgnoreLine.
+		} );
+
+		// Re-sort after translation.
+		asort( $languages );
+
+		return $languages;
+	}
+
+	/**
+	 * Retrieves the plugin configuration.
+	 *
+	 * @return array
+	 */
+	public function get_config() {
+		if ( empty( $this->config ) ) {
+			$config = $this->options->get( Options::CONFIGURATION );
+			if ( is_array( $config ) ) {
+				$this->config = $config;
+			} else {
+				// The configuration array has been corrupted.
+				$this->set_default_options( true );
+			}
+		}
+
+		return $this->config;
+	}
+
+	/**
+	 * Retrieves the internal Settings object for the preferences set via the
+	 * plugin options screen.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return Settings
+	 */
+	public function get_settings() {
+
+		// Initialize Settings instance.
+		if ( empty( $this->typo_settings ) ) {
+			$config    = $this->get_config();
+			$transient = 'php_settings_' . md5( wp_json_encode( $config ) );
+			$settings  = $this->transients->get_large_object( $transient );
+
+			if ( ! $settings instanceof Settings ) {
+				// OK, we have to initialize the PHP_Typography instance manually.
+				$settings = new Settings( false );
+
+				// Load our options into the Settings instance.
+				$this->init_settings_from_options( $settings, $config );
+
+				// Try again next time.
+				$this->transients->cache_object( $transient, $settings, 'settings' );
+			}
+
+			// Make parser errors filterable on an individual level.
+			$settings->set_parser_errors_handler( [ $this, 'parser_errors_handler' ] );
+
+			// Settings should be good now, so let's use them.
+			$this->typo_settings = $settings;
+
+			// Settings won't be touched again, so cache the hash.
+			$this->cached_settings_hash = $this->typo_settings->get_hash( 32, false );
+		}
+
+		return $this->typo_settings;
+	}
+
+	/**
+	 * Processes a heading text fragment.
+	 *
+	 * Calls `process( $text, true, $settings )`.
+	 *
+	 * @since 4.0.0 Parameter $settings added.
+	 *
+	 * @param string        $text Required.
+	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
+	 */
+	public function process_title( $text, Settings $settings = null ) {
+		return $this->process( $text, true, false, $settings );
+	}
+
+	/**
+	 * Processes a heading text fragment as part of an RSS feed.
+	 *
+	 * Calls `process_feed( $text, true, $settings )`.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @param string        $text Required.
+	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
+	 */
+	public function process_feed_title( $text, Settings $settings = null ) {
+		return $this->process_feed( $text, true, $settings );
+	}
+
+	/**
+	 * Processes a content text fragment as part of an RSS feed.
+	 *
+	 * Calls `process( $text, $is_title, true )`.
+	 *
+	 * @since 3.2.4
+	 * @since 4.0.0 Parameter $settings added.
+	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 *
+	 * @param string        $text     Required.
+	 * @param bool          $is_title Optional. Default false.
+	 * @param Settings|null $settings Optional. A settings object. Default null (which means the internal settings will be used).
+	 */
+	public function process_feed( $text, $is_title = false, Settings $settings = null ) {
+		return $this->process( $text, $is_title, true, $settings );
+	}
+
+	/**
+	 * Processes title parts and strips &shy; and zero-width space.
+	 *
+	 * @since 3.2.5
+	 * @since 4.0.0 Parameter $settings added.
+	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 *
+	 * @param array         $title_parts An array of strings.
+	 * @param Settings|null $settings    Optional. A settings object. Default null (which means the internal settings will be used).
+	 *
+	 * @return array
+	 */
+	public function process_title_parts( $title_parts, Settings $settings = null ) {
+		foreach ( $title_parts as $index => $part ) {
+			// Remove "&shy;" and "&#8203;" after processing title part.
+			$title_parts[ $index ] = strip_tags(
+				str_replace( [ \PHP_Typography\U::SOFT_HYPHEN, \PHP_Typography\U::ZERO_WIDTH_SPACE ], '', $this->process( $part, true, true, $settings ) )
+			);
+		}
+
+		return $title_parts;
+	}
+
+	/**
+	 * Processes a text fragment.
+	 *
+	 * @since 3.2.4 Parameter $force_feed added.
+	 * @since 4.0.0 Parameter $settings added.
+	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 *
+	 * @param string        $text       Required.
+	 * @param bool          $is_title   Optional. Default false.
+	 * @param bool          $force_feed Optional. Default false.
+	 * @param Settings|null $settings   Optional. A settings object. Default null (which means the internal settings will be used).
+	 *
+	 * @return string The processed $text.
+	 */
+	public function process( $text, $is_title = false, $force_feed = false, Settings $settings = null ) {
+		// Use default settings if no argument was given.
+		if ( null === $settings ) {
+			$settings = $this->get_settings();
+			$hash     = $this->cached_settings_hash;
+		}
+
+		/**
+		 * Filters the settings object used for processing the text fragment.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param Settings $settings The settings instance.
+		 */
+		$settings = apply_filters( 'typo_settings', $settings );
+
+		// Caclulate hash if necessary.
+		$hash = isset( $hash ) ? $hash : $settings->get_hash( 32, false );
+
+		// Enable feed mode?
+		$feed = $force_feed || is_feed();
+
+		// Construct cache key.
+		$key = 'frag_' . md5( $text ) . '_' . $hash . '_' . ( $feed ? 'f' : '' ) . ( $is_title ? 't' : 's' );
+
+		// Retrieve cached text.
+		$found          = false;
+		$processed_text = $this->cache->get( $key, $found );
+
+		if ( empty( $found ) ) {
+			$typo = $this->get_typography_instance();
+
+			if ( $feed ) { // Feed readers are strange sometimes.
+				$processed_text = $typo->process_feed( $text, $settings, $is_title, $this->body_classes );
+			} else {
+				$processed_text = $typo->process( $text, $settings, $is_title, $this->body_classes );
+			}
+
+			/**
+			 * Filters the caching duration for processed text fragments.
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param int $duration The duration in seconds. Defaults to 1 day.
+			 */
+			$duration = apply_filters( 'typo_processed_text_caching_duration', DAY_IN_SECONDS );
+
+			// Save text fragment for later.
+			$this->cache->set( $key, $processed_text, $duration );
+		}
+
+		return $processed_text;
+	}
+
+	/**
+	 * Grabs the body classes from the filter hook.
+	 *
+	 * @param  string[] $classes An array of CSS classes.
+	 *
+	 * @return string[]
+	 */
+	public function filter_body_class( array $classes ) {
+		$this->body_classes = $classes;
+
+		return $classes;
+	}
+
+	/**
+	 * Retrieves the PHP_Typography instance and ensure just-in-time initialization.
+	 */
+	protected function get_typography_instance() {
+
+		// Retrieve options.
+		$config = $this->get_config();
+
+		// Initialize PHP_Typography instance.
+		if ( empty( $this->typo ) ) {
+			$transient = 'php_' . md5( wp_json_encode( $config ) );
+			$typo      = $this->transients->get_large_object( $transient );
+
+			if ( ! $typo instanceof PHP_Typography ) {
+				// OK, we have to initialize the PHP_Typography instance manually.
+				$typo = new PHP_Typography();
+
+				// Ensure that all fixes are pre-initialized.
+				$typo->get_registry();
+
+				// Try again next time.
+				$this->transients->cache_object( $transient, $typo, 'typography' );
+			}
+
+			$this->typo = $typo;
+		}
+
+		// Also cache hyphenators (the pattern tries are expensive to build).
+		if ( $config[ Config::ENABLE_HYPHENATION ] && empty( $this->hyphenator_cache ) ) {
+			$transient        = 'php_hyphenator_cache';
+			$hyphenator_cache = $this->transients->get_large_object( $transient );
+
+			if ( ! $hyphenator_cache instanceof Hyphenator_Cache ) {
+				$hyphenator_cache = $this->typo->get_hyphenator_cache();
+
+				// Try again next time.
+				$this->transients->cache_object( $transient, $hyphenator_cache, 'hyphenator_cache' );
+			}
+
+			// Let's use it!
+			$this->hyphenator_cache = $hyphenator_cache;
+			$this->typo->set_hyphenator_cache( $this->hyphenator_cache );
+		}
+
+		return $this->typo;
+	}
+
+	/**
+	 * Save hyphenator cache for the next request.
+	 */
+	public function save_hyphenator_cache_on_shutdown() {
+		if ( ! empty( $this->hyphenator_cache ) && $this->hyphenator_cache->has_changed() ) {
+			$this->transients->cache_object( 'php_hyphenator_cache', $this->hyphenator_cache, 'hyphenator_cache' );
+		}
+	}
+
+	/**
+	 * Initializes the Settings object for PHP_Typography from the plugin options.
+	 *
+	 * @param Settings $s      The settings instance to initialize.
+	 * @param array    $config The array of configuration entries.
+	 */
+	protected function init_settings_from_options( Settings $s, array $config ) {
+		// Necessary for full Settings initialization.
+		$s->set_smart_dashes_style( $config[ Config::SMART_DASHES_STYLE ] );
+		$s->set_smart_quotes_primary( $config[ Config::SMART_QUOTES_PRIMARY ] );
+		$s->set_smart_quotes_secondary( $config[ Config::SMART_QUOTES_SECONDARY ] );
+
+		// Load the rest of the configuration variables into our Settings class.
+		$s->set_tags_to_ignore( $config[ Config::IGNORE_TAGS ] );
+		$s->set_classes_to_ignore( $config[ Config::IGNORE_CLASSES ] );
+		$s->set_ids_to_ignore( $config[ Config::IGNORE_IDS ] );
+
+		if ( $config[ Config::SMART_CHARACTERS ] ) {
+			$s->set_smart_dashes( $config[ Config::SMART_DASHES ] );
+			$s->set_smart_ellipses( $config[ Config::SMART_ELLIPSES ] );
+			$s->set_smart_math( $config[ Config::SMART_MATH ] );
+
+			// Note: smart_exponents was grouped with smart_math for the WordPress plugin,
+			// but does not have to be done that way for other ports.
+			$s->set_smart_exponents( $config[ Config::SMART_MATH ] );
+			$s->set_smart_fractions( $config[ Config::SMART_FRACTIONS ] );
+			$s->set_smart_ordinal_suffix( $config[ Config::SMART_ORDINALS ] );
+			$s->set_smart_marks( $config[ Config::SMART_MARKS ] );
+			$s->set_smart_quotes( $config[ Config::SMART_QUOTES ] );
+
+			$s->set_smart_diacritics( $config[ Config::SMART_DIACRITICS ] );
+			$s->set_diacritic_language( $config[ Config::DIACRITIC_LANGUAGES ] );
+			$s->set_diacritic_custom_replacements( $config[ Config::DIACRITIC_CUSTOM_REPLACEMENTS ] );
+		} else {
+			$s->set_smart_dashes( false );
+			$s->set_smart_ellipses( false );
+			$s->set_smart_math( false );
+			$s->set_smart_exponents( false );
+			$s->set_smart_fractions( false );
+			$s->set_smart_ordinal_suffix( false );
+			$s->set_smart_marks( false );
+			$s->set_smart_quotes( false );
+			$s->set_smart_diacritics( false );
+		}
+
+		// Space control.
+		$s->set_single_character_word_spacing( $config[ Config::SINGLE_CHARACTER_WORD_SPACING ] );
+		$s->set_dash_spacing( $config[ Config::DASH_SPACING ] );
+		$s->set_fraction_spacing( $config[ Config::FRACTION_SPACING ] );
+		$s->set_unit_spacing( $config[ Config::UNIT_SPACING ] );
+		$s->set_numbered_abbreviation_spacing( $config[ Config::NUMBERED_ABBREVIATIONS_SPACING ] );
+		$s->set_french_punctuation_spacing( $config[ Config::FRENCH_PUNCTUATION_SPACING ] );
+		$s->set_units( $config[ Config::UNITS ] );
+		$s->set_space_collapse( $config[ Config::SPACE_COLLAPSE ] );
+		$s->set_dewidow( $config[ Config::PREVENT_WIDOWS ] );
+		$s->set_max_dewidow_length( $config[ Config::WIDOW_MIN_LENGTH ] );
+		$s->set_max_dewidow_pull( $config[ Config::WIDOW_MAX_PULL ] );
+
+		/**
+		 * Filters whether to use the NARROW NO-BREAK SPACE character (U+202F, &#8239;)
+		 * where appropriate.
+		 *
+		 * Historically, browser and/or font support for this character has been limited,
+		 * so by default it is replaced by the normal (non-narrow) NO-BREAK SPACE (U+00A0, &nbsp;).
+		 *
+		 * @since 5.1.0
+		 *
+		 * @param bool $enable Default false.
+		 */
+		$s->set_true_no_break_narrow_space( apply_filters( 'typo_narrow_no_break_space', false ) );
+
+		// Line wrapping.
+		$s->set_wrap_hard_hyphens( $config[ Config::WRAP_HYPHENS ] );
+		$s->set_email_wrap( $config[ Config::WRAP_EMAILS ] );
+		$s->set_url_wrap( $config[ Config::WRAP_URLS ] );
+		$s->set_min_after_url_wrap( $config[ Config::WRAP_MIN_AFTER ] );
+
+		// CSS hooks.
+		$s->set_style_ampersands( $config[ Config::STYLE_AMPS ] );
+		$s->set_style_caps( $config[ Config::STYLE_CAPS ] );
+		$s->set_style_numbers( $config[ Config::STYLE_NUMBERS ] );
+		$s->set_style_hanging_punctuation( $config[ Config::STYLE_HANGING_PUNCTUATION ] );
+		$s->set_style_initial_quotes( $config[ Config::STYLE_INITIAL_QUOTES ] );
+		$s->set_initial_quote_tags( $config[ Config::INITIAL_QUOTE_TAGS ] );
+
+		if ( $config[ Config::ENABLE_HYPHENATION ] ) {
+			$s->set_hyphenation( $config[ Config::ENABLE_HYPHENATION ] );
+			$s->set_hyphenate_headings( $config[ Config::HYPHENATE_HEADINGS ] );
+			$s->set_hyphenate_all_caps( $config[ Config::HYPHENATE_CAPS ] );
+			$s->set_hyphenate_title_case( $config[ Config::HYPHENATE_TITLE_CASE ] );
+			$s->set_hyphenate_compounds( $config[ Config::HYPHENATE_COMPOUNDS ] );
+			$s->set_hyphenation_language( $config[ Config::HYPHENATE_LANGUAGES ] );
+			$s->set_min_length_hyphenation( $config[ Config::HYPHENATE_MIN_LENGTH ] );
+			$s->set_min_before_hyphenation( $config[ Config::HYPHENATE_MIN_BEFORE ] );
+			$s->set_min_after_hyphenation( $config[ Config::HYPHENATE_MIN_AFTER ] );
+			$s->set_hyphenation_exceptions( $config[ Config::HYPHENATE_EXCEPTIONS ] );
+		} else { // save some cycles.
+			$s->set_hyphenation( $config[ Config::ENABLE_HYPHENATION ] );
+		}
+
+		/**
+		 * Filters whether HTML parser errors should be silently ignored.
+		 *
+		 * The resulting HTML will be a "best guess" by the parser, like it was before version 3.5.2.
+		 *
+		 * @since 3.6.0
+		 *
+		 * @param bool $ignore Default false.
+		 */
+		$s->set_ignore_parser_errors( $config[ Config::IGNORE_PARSER_ERRORS ] || apply_filters( 'typo_ignore_parser_errors', false ) );
+	}
+
+	/**
+	 * Initializes the options with default values.
+	 *
+	 * @param bool $force_defaults Optional. Default false.
+	 */
+	public function set_default_options( $force_defaults = false ) {
+		$update = $force_defaults;
+
+		// Grab configuration variables.
+		foreach ( $this->get_default_options() as $key => $default ) {
+			// Set or update the options with the default value if necessary.
+			if ( $force_defaults || ! isset( $this->config[ $key ] ) ) {
+				$this->config[ $key ] = $default;
+				$update               = true;
+			}
+		}
+
+		// Update stored options.
+		if ( $update ) {
+			$this->options->set( Options::CONFIGURATION, $this->config );
+		}
+
+		if ( $force_defaults ) {
+			// Push the reset switch.
+			$this->options->delete( Options::RESTORE_DEFAULTS );
+			$this->options->delete( Options::CLEAR_CACHE );
+		}
+	}
+
+	/**
+	 * Retrieves the plugin's default option values.
+	 *
+	 * @return array
+	 */
+	public function get_default_options() {
+		if ( empty( $this->default_settings ) ) {
+			/**
+			 * Filters the default settings used to initialize the plugin.
+			 *
+			 * @since 5.1.0
+			 *
+			 * @param array $defaults The default settings indexed by their configuration key.
+			 */
+			$this->default_settings = (array) apply_filters( 'typo_plugin_defaults', wp_list_pluck( Config::get_defaults(), 'default' ) );
+		}
+
+		return $this->default_settings;
+	}
+
+	/**
+	 * Clears all transients set by the plugin.
+	 */
+	public function clear_cache() {
+		$this->transients->invalidate();
+		$this->cache->invalidate();
+
+		$this->options->delete( Options::CLEAR_CACHE );
+	}
+
+	/**
+	 * Makes parser errors filterable.
+	 *
+	 * @param array $errors An array of error messages.
+	 *
+	 * @return array The filtered array.
+	 */
+	public function parser_errors_handler( $errors ) {
+		/**
+		 * Filters the HTML parser errors (if there are any).
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param array $errors An array of error messages.
+		 */
+		return apply_filters( 'typo_handle_parser_errors', $errors );
+	}
+
+	/**
+	 * Retrieves the plugin version.
+	 *
+	 * @return string
+	 */
+	public function get_version() {
+		return $this->version;
+	}
+}

--- a/includes/wp-typography/class-plugin-controller.php
+++ b/includes/wp-typography/class-plugin-controller.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography;
+
+use WP_Typography\Components\Admin_Interface;
+use WP_Typography\Components\Common;
+use WP_Typography\Components\Multilingual_Support;
+use WP_Typography\Components\Plugin_Component;
+use WP_Typography\Components\Public_Interface;
+use WP_Typography\Components\Setup;
+
+use WP_Typography\Data_Storage\Cache;
+use WP_Typography\Data_Storage\Options;
+use WP_Typography\Data_Storage\Transients;
+
+/**
+ * Registers and runs the various plugin components.
+ *
+ * @since 5.3.0
+ */
+class Plugin_Controller {
+
+	/**
+	 * The plugin API facade.
+	 *
+	 * @var \WP_Typography
+	 */
+	private $facade;
+
+	/**
+	 * The plugin components in order of execution.
+	 *
+	 * @var Plugin_Component[]
+	 */
+	private $plugin_components = [];
+
+	/**
+	 * Sets up a new plugin controller instance.
+	 *
+	 * @param \WP_Typography       $facade      Required.
+	 * @param Setup                $setup       Required.
+	 * @param Common               $common      Required.
+	 * @param Admin_Interface      $admin       Required.
+	 * @param Public_Interface     $public_if   Required.
+	 * @param Multilingual_Support $multi       Required.
+	 * @param Transients           $transients  Required.
+	 * @param Cache                $cache       Required.
+	 * @param Options              $options     Required.
+	 */
+	public function __construct( \WP_Typography $facade, Setup $setup, Common $common, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi, Transients $transients, Cache $cache, Options $options ) {
+		// Basic set-up.
+		$this->facade = $facade;
+
+		// Initialize cache handlers.
+		$this->transients = $transients;
+		$this->cache      = $cache;
+
+		// Initialize Options API handler.
+		$this->options = $options;
+
+		// Initialize activation/deactivation handler.
+		$this->plugin_components[] = $setup;
+
+		// Initialize common component.
+		$this->plugin_components[] = $common;
+
+		// Initialize multilingual support.
+		$this->plugin_components[] = $multi;
+
+		// Initialize public interface handler.
+		$this->plugin_components[] = $public_if;
+
+		// Initialize admin interface handler.
+		$this->plugin_components[] = $admin;
+	}
+
+	/**
+	 * Starts the plugin for real.
+	 */
+	public function run() {
+		// Set plugin singleton.
+		\WP_Typography::set_instance( $this->facade );
+
+		// Run all the plugin components.
+		foreach ( $this->plugin_components as $component ) {
+			$component->run( $this->facade );
+		}
+	}
+}

--- a/includes/wp-typography/class-plugin-controller.php
+++ b/includes/wp-typography/class-plugin-controller.php
@@ -45,11 +45,11 @@ use WP_Typography\Data_Storage\Transients;
 class Plugin_Controller {
 
 	/**
-	 * The plugin API facade.
+	 * The plugin API implementation.
 	 *
-	 * @var \WP_Typography
+	 * @var \WP_Typography\Implementation
 	 */
-	private $facade;
+	private $api;
 
 	/**
 	 * The plugin components in order of execution.
@@ -61,26 +61,16 @@ class Plugin_Controller {
 	/**
 	 * Sets up a new plugin controller instance.
 	 *
-	 * @param \WP_Typography       $facade      Required.
+	 * @param Implementation       $api         Required.
 	 * @param Setup                $setup       Required.
 	 * @param Common               $common      Required.
 	 * @param Admin_Interface      $admin       Required.
 	 * @param Public_Interface     $public_if   Required.
 	 * @param Multilingual_Support $multi       Required.
-	 * @param Transients           $transients  Required.
-	 * @param Cache                $cache       Required.
-	 * @param Options              $options     Required.
 	 */
-	public function __construct( \WP_Typography $facade, Setup $setup, Common $common, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi, Transients $transients, Cache $cache, Options $options ) {
+	public function __construct( Implementation $api, Setup $setup, Common $common, Admin_Interface $admin, Public_Interface $public_if, Multilingual_Support $multi ) {
 		// Basic set-up.
-		$this->facade = $facade;
-
-		// Initialize cache handlers.
-		$this->transients = $transients;
-		$this->cache      = $cache;
-
-		// Initialize Options API handler.
-		$this->options = $options;
+		$this->api = $api;
 
 		// Initialize activation/deactivation handler.
 		$this->plugin_components[] = $setup;
@@ -103,11 +93,11 @@ class Plugin_Controller {
 	 */
 	public function run() {
 		// Set plugin singleton.
-		\WP_Typography::set_instance( $this->facade );
+		\WP_Typography::set_instance( $this->api );
 
 		// Run all the plugin components.
 		foreach ( $this->plugin_components as $component ) {
-			$component->run( $this->facade );
+			$component->run( $this->api );
 		}
 	}
 }

--- a/includes/wp-typography/components/class-admin-interface.php
+++ b/includes/wp-typography/components/class-admin-interface.php
@@ -501,8 +501,8 @@ class Admin_Interface implements Plugin_Component {
 	 * Display the plugin options page.
 	 */
 	public function get_admin_page_content() {
-		$this->admin_form_controls[ Config::HYPHENATE_LANGUAGES ]->set_option_values( $this->plugin->load_hyphenation_languages() );
-		$this->admin_form_controls[ Config::DIACRITIC_LANGUAGES ]->set_option_values( $this->plugin->load_diacritic_languages() );
+		$this->admin_form_controls[ Config::HYPHENATE_LANGUAGES ]->set_option_values( $this->plugin->get_hyphenation_languages() );
+		$this->admin_form_controls[ Config::DIACRITIC_LANGUAGES ]->set_option_values( $this->plugin->get_diacritic_languages() );
 
 		// Load the settings page HTML.
 		require \dirname( $this->plugin_file ) . '/admin/partials/settings/settings-page.php';

--- a/includes/wp-typography/components/class-multilingual-support.php
+++ b/includes/wp-typography/components/class-multilingual-support.php
@@ -109,8 +109,8 @@ class Multilingual_Support implements Plugin_Component {
 	 */
 	public function add_plugin_defaults_filter() {
 		// Translation of language names is irrelevant here.
-		$this->hyphenation_languages = $this->plugin->load_hyphenation_languages();
-		$this->diacritic_languages   = $this->plugin->load_diacritic_languages();
+		$this->hyphenation_languages = $this->plugin->get_hyphenation_languages();
+		$this->diacritic_languages   = $this->plugin->get_diacritic_languages();
 
 		// Filter the defaults.
 		\add_filter( 'typo_plugin_defaults', [ $this, 'filter_defaults' ] );

--- a/includes/wp-typography/components/class-multilingual-support.php
+++ b/includes/wp-typography/components/class-multilingual-support.php
@@ -26,8 +26,6 @@
 
 namespace WP_Typography\Components;
 
-use WP_Typography;
-
 use WP_Typography\Settings\Basic_Locale_Settings;
 use WP_Typography\Settings\Locale_Settings;
 use WP_Typography\Settings\Plugin_Configuration as Config;
@@ -90,9 +88,9 @@ class Multilingual_Support implements Plugin_Component {
 	/**
 	 * Set up the various hooks for multilingual support.
 	 *
-	 * @param WP_Typography $plugin The main plugin instance.
+	 * @param \WP_Typography $plugin The main plugin instance.
 	 */
-	public function run( WP_Typography $plugin ) {
+	public function run( \WP_Typography $plugin ) {
 		// Store plugin reference.
 		$this->plugin = $plugin;
 

--- a/tests/class-plugin-controller-test.php
+++ b/tests/class-plugin-controller-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017-2018 Peter Putzer.
+ *  Copyright 2018 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -24,7 +24,9 @@
 
 namespace WP_Typography\Tests;
 
-use PHP_Typography\Hyphenator_Cache;
+use WP_Typography\Plugin_Controller;
+use WP_Typography\Components\Admin_Interface;
+use WP_Typography\Components\Public_Interface;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
@@ -33,15 +35,12 @@ use Brain\Monkey\Functions;
 use Mockery as m;
 
 /**
- * WP_Typography unit test for the singleton methods.
+ * Unit tests for plugin controller.
  *
- * @coversDefaultClass \WP_Typography
- * @usesDefaultClass \WP_Typography
- *
- * @uses ::__construct
- * @uses ::hash_version_string
+ * @coversDefaultClass \WP_Typography\Plugin_Controller
+ * @usesDefaultClass \WP_Typography\Plugin_Controller
  */
-class WP_Typography_Singleton_Test extends TestCase {
+class Plugin_Controller_Test extends TestCase {
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -55,7 +54,6 @@ class WP_Typography_Singleton_Test extends TestCase {
 	 * Necesssary clean-up work.
 	 */
 	protected function tearDown() { // @codingStandardsIgnoreLine
-
 		// Reset singleton.
 		$this->setStaticValue( \WP_Typography::class, '_instance', null );
 
@@ -65,22 +63,28 @@ class WP_Typography_Singleton_Test extends TestCase {
 	/**
 	 * Tests singleton methods.
 	 *
-	 * @covers ::get_instance
-	 * @covers ::set_instance
-	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
-	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
-	 * @uses \WP_Typography\Data_Storage\Cache::__construct
-	 * @uses \WP_Typography\Data_Storage\Options::__construct
-	 * @uses \WP_Typography\Data_Storage\Transients::__construct
+	 * @covers ::__construct
 	 */
-	public function test_singleton() {
+	public function test_constructor() {
+
+		$multi = m::mock( \WP_Typography\Components\Multilingual_Support::class )
+			->shouldReceive( 'run' )->byDefault()
+			->getMock();
 
 		// Mock WP_Typography\Data_Storage\Options instance.
 		$options = m::mock( \WP_Typography\Data_Storage\Options::class )
 			->shouldReceive( 'get' )->andReturn( false )->byDefault()
 			->shouldReceive( 'set' )->andReturn( false )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Components\Setup instance.
+		$setup = m::mock( \WP_Typography\Components\Setup::class )
+			->shouldReceive( 'run' )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Components\Common instance.
+		$common = m::mock( \WP_Typography\Components\Common::class )
+			->shouldReceive( 'run' )->byDefault()
 			->getMock();
 
 		// Mock WP_Typography\Data_Storage\Transients instance.
@@ -98,54 +102,41 @@ class WP_Typography_Singleton_Test extends TestCase {
 			->shouldReceive( 'invalidate' )->byDefault()
 			->getMock();
 
-		$typo = new \WP_Typography( '6.6.6', $transients, $cache, $options );
-		\WP_Typography::set_instance( $typo );
+		// Mock WP_Typography\Components\Admin_Interface instance.
+		$admin = m::mock( Admin_Interface::class )
+			->shouldReceive( 'run' )->shouldReceive( 'get_default_settings' )->andReturn( [] )->byDefault()
+			->getMock();
 
-		$typo2 = \WP_Typography::get_instance();
-		$this->assertSame( $typo, $typo2 );
+		// Mock Public_Interface instance.
+		$public_if = m::mock( Public_Interface::class )
+			->shouldReceive( 'run' )->byDefault()
+			->getMock();
 
-		$this->assertInstanceOf( \WP_Typography::class, $typo );
-		$this->assertAttributeSame( '6.6.6', 'version', $typo );
+		$typo = m::mock( \WP_Typography::class );
 
-		// Check ::get_instance (no underscore).
-		$typo3 = \WP_Typography::get_instance();
-		$this->assertSame( $typo, $typo3 );
+		$controller = new \WP_Typography\Plugin_Controller( $typo, $setup, $common, $admin, $public_if, $multi, $transients, $cache, $options );
+
+		$this->assertInstanceOf( \WP_Typography\Plugin_Controller::class, $controller );
+
+		return $controller;
 	}
 
 	/**
-	 * Tests ::get_instance without a previous call to ::_get_instance (i.e. _doing_it_wrong).
+	 * Tests constructor.
 	 *
-	 * @covers ::get_instance
+	 * @depends test_constructor
 	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
+	 * @covers ::run
 	 *
-	 * @expectedException \BadMethodCallException
-	 * @expectedExceptionMessage WP_Typography::get_instance called without prior plugin intialization.
+	 * @uses \WP_Typography::set_instance
+	 *
+	 * @param Plugin_Controller $controller Required.
 	 */
-	public function test_get_instance_failing() {
-		$typo = \WP_Typography::get_instance();
-		$this->assertInstanceOf( \WP_Typography::class, $typo );
-	}
+	public function test_run( $controller ) {
+		foreach ( $this->getValue( $controller, 'plugin_components', Plugin_Controller::class ) as $component ) {
+			$component->shouldReceive( 'run' )->once()->with( m::type( \WP_Typography::class ) );
+		}
 
-	/**
-	 * Tests ::get_instance without a previous call to ::_get_instance (i.e. _doing_it_wrong).
-	 *
-	 * @covers ::set_instance
-	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
-	 *
-	 * @expectedException \BadMethodCallException
-	 * @expectedExceptionMessage WP_Typography::set_instance called more than once.
-	 */
-	public function test_set_instance_failing() {
-		$transients = m::mock( \WP_Typography\Data_Storage\Transients::class );
-		$cache      = m::mock( \WP_Typography\Data_Storage\Cache::class );
-		$options    = m::mock( \WP_Typography\Data_Storage\Options::class );
-
-		$typo = new \WP_Typography( '6.6.6', $transients, $cache, $options );
-		\WP_Typography::set_instance( $typo );
-		\WP_Typography::set_instance( $typo );
+		$this->assertNull( $controller->run() );
 	}
 }

--- a/tests/class-plugin-controller-test.php
+++ b/tests/class-plugin-controller-test.php
@@ -112,7 +112,7 @@ class Plugin_Controller_Test extends TestCase {
 			->shouldReceive( 'run' )->byDefault()
 			->getMock();
 
-		$typo = m::mock( \WP_Typography::class );
+		$typo = m::mock( \WP_Typography\Implementation::class );
 
 		$controller = new \WP_Typography\Plugin_Controller( $typo, $setup, $common, $admin, $public_if, $multi, $transients, $cache, $options );
 

--- a/tests/class-wp-typography-imlementation-test.php
+++ b/tests/class-wp-typography-imlementation-test.php
@@ -1,0 +1,655 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2017-2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or ( at your option ) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  @package mundschenk-at/wp-typography/tests
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests;
+
+use WP_Typography\Data_Storage\Options;
+use WP_Typography\Settings\Plugin_Configuration as Config;
+
+use PHP_Typography\Hyphenator_Cache;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+/**
+ * WP_Typography\Implementation unit test.
+ *
+ * @coversDefaultClass \WP_Typography\Implementation
+ * @usesDefaultClass \WP_Typography\Implementation
+ *
+ * @uses ::__construct
+ * @uses ::hash_version_string
+ * @uses \WP_Typography\Components\Admin_Interface::__construct
+ * @uses \WP_Typography\Components\Public_Interface::__construct
+ * @uses \WP_Typography\Components\Setup::__construct
+ * @uses \WP_Typography\Components\Common::__construct
+ */
+class WP_Typography_Implementation_Test extends TestCase {
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var \WP_Typography\Implementation
+	 */
+	protected $wp_typo;
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var \WP_Typography\Data_Storage\Transients
+	 */
+	protected $transients;
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var \WP_Typography\Data_Storage\Cache
+	 */
+	protected $cache;
+
+	/**
+	 * Test fixture.
+	 *
+	 * @var \WP_Typography\Data_Storage\Options
+	 */
+	protected $options;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() { // @codingStandardsIgnoreLine
+
+		// Mock WP_Typography\Data_Storage\Options instance.
+		$this->options = m::mock( \WP_Typography\Data_Storage\Options::class )
+			->shouldReceive( 'get' )->andReturn( false )->byDefault()
+			->shouldReceive( 'set' )->andReturn( false )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Data_Storage\Transients instance.
+		$this->transients = m::mock( \WP_Typography\Data_Storage\Transients::class )
+			->shouldReceive( 'get' )->byDefault()->andReturn( false )
+			->shouldReceive( 'get_large_object' )->byDefault()->andReturn( false )
+			->shouldReceive( 'set' )->andReturn( false )->byDefault()
+			->shouldReceive( 'set_large_object' )->andReturn( false )->byDefault()
+			->getMock();
+
+		// Mock WP_Typography\Data_Storage\Cache instance.
+		$this->cache = m::mock( \WP_Typography\Data_Storage\Cache::class )
+			->shouldReceive( 'get' )->andReturn( false )->byDefault()
+			->shouldReceive( 'set' )->andReturn( false )->byDefault()
+			->shouldReceive( 'invalidate' )->byDefault()
+			->getMock();
+
+		// Create instance.
+		$this->wp_typo = m::mock( \WP_Typography\Implementation::class, [ '7.7.7', $this->transients, $this->cache, $this->options ] )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Necesssary clean-up work.
+	 */
+	protected function tearDown() { // @codingStandardsIgnoreLine
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests constructor.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses ::get_version
+	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
+	 * @uses \WP_Typography\Data_Storage\Cache::__construct
+	 * @uses \WP_Typography\Data_Storage\Cache::invalidate
+	 * @uses \WP_Typography\Data_Storage\Options::__construct
+	 * @uses \WP_Typography\Data_Storage\Transients::__construct
+	 * @uses \WP_Typography\Data_Storage\Transients::invalidate
+	 * @uses \WP_Typography\Data_Storage\Transients::get_keys_from_database
+	 */
+	public function test_constructor() {
+
+		$typo = new \WP_Typography\Implementation(
+			'6.6.6',
+			m::mock( \WP_Typography\Data_Storage\Transients::class ),
+			m::mock( \WP_Typography\Data_Storage\Cache::class ),
+			m::mock( \WP_Typography\Data_Storage\Options::class )
+		);
+
+		$this->assertInstanceOf( \WP_Typography\Implementation::class, $typo );
+		$this->assertAttributeSame( '6.6.6', 'version', $typo );
+	}
+
+	/**
+	 * Test get_typography_instance.
+	 *
+	 * @covers ::get_typography_instance
+	 */
+	public function test_get_typography_instance() {
+		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
+			Config::ENABLE_HYPHENATION => true,
+		] );
+
+		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
+
+		$this->transients->shouldReceive( 'cache_object' )->twice();
+
+		$this->assertInstanceOf( \PHP_Typography\PHP_Typography::class, $this->invokeMethod( $this->wp_typo, 'get_typography_instance' ) );
+	}
+
+	/**
+	 * Test get_config.
+	 *
+	 * @covers ::get_config
+	 */
+	public function test_get_config() {
+
+		$this->options->shouldReceive( 'get' )->once()->with( Options::CONFIGURATION )->andReturn( [ 'foo' => 'bar' ] );
+
+		$this->assertInternalType( 'array', $this->wp_typo->get_config() );
+	}
+
+	/**
+	 * Test get_config with corrupted option.
+	 *
+	 * @covers ::get_config
+	 */
+	public function test_get_config_corrupted() {
+
+		$this->options->shouldReceive( 'get' )->once()->with( Options::CONFIGURATION )->andReturn( 'wrong' );
+		$this->wp_typo->shouldReceive( 'set_default_options' )->once()->with( true );
+
+		// IRL set_default_options would fix the config object.
+		$this->assertSame( null, $this->wp_typo->get_config() );
+	}
+
+	/**
+	 * Test get_user_settings.
+	 *
+	 * @covers ::get_settings
+	 * @covers ::init_settings_from_options
+	 *
+	 * @uses ::init_settings_from_options
+	 */
+	public function test_get_settings() {
+
+		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
+			Config::IGNORE_TAGS                    => [ 'script' ],
+			Config::IGNORE_CLASSES                 => [ 'noTypo' ],
+			Config::IGNORE_IDS                     => [],
+			Config::SMART_CHARACTERS               => true,
+			Config::SMART_DASHES                   => false,
+			Config::SMART_DASHES_STYLE             => 'international',
+			Config::SMART_ELLIPSES                 => false,
+			Config::SMART_MATH                     => false,
+			Config::SMART_FRACTIONS                => false,
+			Config::SMART_ORDINALS                 => false,
+			Config::SMART_MARKS                    => false,
+			Config::SMART_QUOTES                   => false,
+			Config::SMART_DIACRITICS               => false,
+			Config::DIACRITIC_LANGUAGES            => 'en-US',
+			Config::DIACRITIC_CUSTOM_REPLACEMENTS  => [],
+			Config::SMART_QUOTES_PRIMARY           => 'doubleCurled',
+			Config::SMART_QUOTES_SECONDARY         => 'singleCurled',
+			Config::SINGLE_CHARACTER_WORD_SPACING  => false,
+			Config::DASH_SPACING                   => false,
+			Config::FRACTION_SPACING               => false,
+			Config::UNIT_SPACING                   => false,
+			Config::NUMBERED_ABBREVIATIONS_SPACING => false,
+			Config::FRENCH_PUNCTUATION_SPACING     => false,
+			Config::UNITS                          => [],
+			Config::SPACE_COLLAPSE                 => false,
+			Config::PREVENT_WIDOWS                 => false,
+			Config::WIDOW_MIN_LENGTH               => 2,
+			Config::WIDOW_MAX_PULL                 => 2,
+			Config::WRAP_HYPHENS                   => false,
+			Config::WRAP_EMAILS                    => false,
+			Config::WRAP_URLS                      => false,
+			Config::WRAP_MIN_AFTER                 => 2,
+			Config::STYLE_AMPS                     => false,
+			Config::STYLE_CAPS                     => false,
+			Config::STYLE_NUMBERS                  => false,
+			Config::WRAP_URLS                      => false,
+			Config::STYLE_HANGING_PUNCTUATION      => false,
+			Config::STYLE_INITIAL_QUOTES           => false,
+			Config::INITIAL_QUOTE_TAGS             => [],
+			Config::ENABLE_HYPHENATION             => true,
+			Config::HYPHENATE_HEADINGS             => false,
+			Config::HYPHENATE_CAPS                 => false,
+			Config::HYPHENATE_TITLE_CASE           => false,
+			Config::HYPHENATE_COMPOUNDS            => false,
+			Config::HYPHENATE_LANGUAGES            => 'en-US',
+			Config::HYPHENATE_MIN_LENGTH           => 2,
+			Config::HYPHENATE_MIN_BEFORE           => 2,
+			Config::HYPHENATE_MIN_AFTER            => 2,
+			Config::HYPHENATE_EXCEPTIONS           => [],
+			Config::IGNORE_PARSER_ERRORS           => false,
+			Config::ENABLE_MULTILINGUAL_SUPPORT    => false,
+		] );
+		$this->transients->shouldReceive( 'cache_object' )->once();
+
+		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
+
+		$s = $this->wp_typo->get_settings();
+
+		$this->assertInstanceOf( \PHP_Typography\Settings::class, $s );
+	}
+
+	/**
+	 * Test get_user_settings.
+	 *
+	 * @covers ::get_settings
+	 * @covers ::init_settings_from_options
+	 *
+	 * @uses ::init_settings_from_options
+	 */
+	public function test_get_settings_hyphenation_off() {
+
+		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
+			Config::IGNORE_TAGS                    => [ 'script' ],
+			Config::IGNORE_CLASSES                 => [ 'noTypo' ],
+			Config::IGNORE_IDS                     => [],
+			Config::SMART_CHARACTERS               => false,
+			Config::SMART_DASHES                   => false,
+			Config::SMART_DASHES_STYLE             => 'international',
+			Config::SMART_ELLIPSES                 => false,
+			Config::SMART_MATH                     => false,
+			Config::SMART_FRACTIONS                => false,
+			Config::SMART_ORDINALS                 => false,
+			Config::SMART_MARKS                    => false,
+			Config::SMART_QUOTES                   => false,
+			Config::SMART_DIACRITICS               => false,
+			Config::DIACRITIC_LANGUAGES            => 'en-US',
+			Config::DIACRITIC_CUSTOM_REPLACEMENTS  => [],
+			Config::SMART_QUOTES_PRIMARY           => 'doubleCurled',
+			Config::SMART_QUOTES_SECONDARY         => 'singleCurled',
+			Config::SINGLE_CHARACTER_WORD_SPACING  => false,
+			Config::DASH_SPACING                   => false,
+			Config::FRACTION_SPACING               => false,
+			Config::UNIT_SPACING                   => false,
+			Config::NUMBERED_ABBREVIATIONS_SPACING => false,
+			Config::FRENCH_PUNCTUATION_SPACING     => false,
+			Config::UNITS                          => [],
+			Config::SPACE_COLLAPSE                 => false,
+			Config::PREVENT_WIDOWS                 => false,
+			Config::WIDOW_MIN_LENGTH               => 2,
+			Config::WIDOW_MAX_PULL                 => 2,
+			Config::WRAP_HYPHENS                   => false,
+			Config::WRAP_EMAILS                    => false,
+			Config::WRAP_URLS                      => false,
+			Config::WRAP_MIN_AFTER                 => 2,
+			Config::STYLE_AMPS                     => false,
+			Config::STYLE_CAPS                     => false,
+			Config::STYLE_NUMBERS                  => false,
+			Config::WRAP_URLS                      => false,
+			Config::STYLE_HANGING_PUNCTUATION      => false,
+			Config::STYLE_INITIAL_QUOTES           => false,
+			Config::INITIAL_QUOTE_TAGS             => [],
+			Config::ENABLE_HYPHENATION             => false,
+			Config::HYPHENATE_HEADINGS             => false,
+			Config::HYPHENATE_CAPS                 => false,
+			Config::HYPHENATE_TITLE_CASE           => false,
+			Config::HYPHENATE_COMPOUNDS            => false,
+			Config::HYPHENATE_LANGUAGES            => 'en-US',
+			Config::HYPHENATE_MIN_LENGTH           => 2,
+			Config::HYPHENATE_MIN_BEFORE           => 2,
+			Config::HYPHENATE_MIN_AFTER            => 2,
+			Config::HYPHENATE_EXCEPTIONS           => [],
+			Config::IGNORE_PARSER_ERRORS           => false,
+		] );
+		$this->transients->shouldReceive( 'cache_object' )->once();
+
+		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
+
+		$s = $this->wp_typo->get_settings();
+
+		$this->assertInstanceOf( \PHP_Typography\Settings::class, $s );
+	}
+
+	/**
+	 * Test get_hyphenation_languages
+	 *
+	 * @covers ::get_hyphenation_languages
+	 * @covers ::load_languages
+	 * @covers ::translate_languages
+	 *
+	 * @uses \PHP_Typography\PHP_Typography::get_hyphenation_languages
+	 */
+	public function test_get_hyphenation_languages() {
+		Functions\when( '_x' )->returnArg();
+		if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+			define( 'WEEK_IN_SECONDS', 999 );
+		}
+
+		$this->cache->shouldReceive( 'get' )->once()->andReturnUsing( function( $key, &$found ) {
+			$found = false;
+			return [];
+		} )->shouldReceive( 'set' )->once();
+
+		$langs = $this->wp_typo->get_hyphenation_languages();
+
+		$this->assertContainsOnly( 'string', $langs, 'The languages array should only contain strings.' );
+		$this->assertContainsOnly( 'string', array_keys( $langs ), 'The languages array should be indexed by language codes.' );
+	}
+
+	/**
+	 * Test get_hyphenation_languages
+	 *
+	 * @covers ::get_diacritic_languages
+	 * @covers ::load_languages
+	 * @covers ::translate_languages
+	 *
+	 * @uses \PHP_Typography\PHP_Typography::get_hyphenation_languages
+	 */
+	public function test_get_diacritic_languages() {
+		Functions\when( '_x' )->returnArg();
+		if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+			define( 'WEEK_IN_SECONDS', 999 );
+		}
+
+		$this->cache->shouldReceive( 'get' )->once()->andReturnUsing( function( $key, &$found ) {
+			$found = false;
+			return [];
+		} )->shouldReceive( 'set' )->once();
+
+		$langs = $this->wp_typo->get_diacritic_languages();
+
+		$this->assertContainsOnly( 'string', $langs, 'The languages array should only contain strings.' );
+		$this->assertContainsOnly( 'string', array_keys( $langs ), 'The languages array should be indexed by language codes.' );
+	}
+
+	/**
+	 * Test process_title.
+	 *
+	 * @covers ::process_title
+	 */
+	public function test_process_title() {
+		$this->wp_typo->shouldReceive( 'process' )->once()->with( 'foobar', true, false, null )->andReturn( 'barfoo' );
+
+		$this->assertSame( 'barfoo', $this->wp_typo->process_title( 'foobar', null ) );
+	}
+
+	/**
+	 * Test process_feed.
+	 *
+	 * @covers ::process_feed
+	 */
+	public function test_process_feed() {
+		$this->wp_typo->shouldReceive( 'process' )->once()->with( 'foobar', true, true, null )->andReturn( 'barfoo' );
+
+		$this->assertSame( 'barfoo', $this->wp_typo->process_feed( 'foobar', true, null ) );
+	}
+
+	/**
+	 * Test process_feed_title.
+	 *
+	 * @covers ::process_feed_title
+	 */
+	public function test_process_feed_title() {
+		$this->wp_typo->shouldReceive( 'process_feed' )->once()->with( 'foobar', true, null )->andReturn( 'barfoo' );
+
+		$this->assertSame( 'barfoo', $this->wp_typo->process_feed_title( 'foobar', null ) );
+	}
+
+
+	/**
+	 * Test process_title_parts.
+	 *
+	 * @covers ::process_title_parts
+	 */
+	public function test_process_title_parts() {
+		$title_parts = [
+			'fo' . \PHP_Typography\U::SOFT_HYPHEN . 'o',
+			'bar',
+			'baz',
+		];
+
+		foreach ( $title_parts as $part ) {
+			$this->wp_typo->shouldReceive( 'process' )->once()->with( $part, true, true, null )->andReturn( $part . $part );
+		}
+
+		$this->assertSame( [ 'foofoo', 'barbar', 'bazbaz' ], $this->wp_typo->process_title_parts( $title_parts, null ) );
+	}
+
+	/**
+	 * Provide data for testing process.
+	 *
+	 * @return array
+	 */
+	public function provide_process_data() {
+		return [
+			[ true, true, true, null ],
+			[ false, false, false, null ],
+			[ false, true, false, null ],
+			[ false, false, true, null ],
+			[ true, false, true, null ],
+			[ false, false, false, m::mock( \PHP_Typography\Settings::class )->shouldReceive( 'get_hash' )->andReturn( 'another_fake_hash' )->getMock() ],
+		];
+	}
+
+	/**
+	 * Test process
+	 *
+	 * @covers ::process
+	 *
+	 * @uses ::set_instance
+	 *
+	 * @dataProvider provide_process_data
+	 *
+	 * @param  bool     $is_title   Fragment is a title.
+	 * @param  bool     $force_feed Enforce feed processing.
+	 * @param  bool     $is_feed    Value for is_feed().
+	 * @param  Settings $settings   May be null.
+	 */
+	public function test_process( $is_title, $force_feed, $is_feed, $settings = null ) {
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 999 );
+		}
+
+		Functions\expect( 'is_feed' )->andReturn( $is_feed );
+
+		if ( null === $settings ) {
+			$settings_mock = m::mock( \PHP_Typography\Settings::class )->shouldReceive( 'get_hash' )->andReturn( 'another_fake_hash' )->getMock();
+
+			$this->wp_typo->shouldReceive( 'get_settings' )->once()->andReturn( $settings_mock );
+		}
+
+		// Fake filter_body_classes.
+		$this->setValue( $this->wp_typo, 'body_classes', [ 'foo', 'bar' ], \WP_Typography\Implementation::class );
+
+		Filters\expectApplied( 'typo_settings' )->once()->with( m::type( \PHP_Typography\Settings::class ) )->andReturnFirstArg();
+		Filters\expectApplied( 'typo_processed_text_caching_duration' )->once()->with( m::type( 'int' ) )->andReturn( 5 );
+
+		$typo_mock = m::mock( \PHP_Typography\PHP_Typography::class );
+		$this->wp_typo->shouldReceive( 'get_typography_instance' )->once()->andReturn( $typo_mock );
+		if ( $is_feed || $force_feed ) {
+			$typo_mock->shouldReceive( 'process_feed' )->once()->with( 'text', m::type( \PHP_Typography\Settings::class ), $is_title, [ 'foo', 'bar' ] )->andReturn( 'processed text' );
+		} else {
+			$typo_mock->shouldReceive( 'process' )->once()->with( 'text', m::type( \PHP_Typography\Settings::class ), $is_title, [ 'foo', 'bar' ] )->andReturn( 'processed text' );
+		}
+
+		$this->cache
+			->shouldReceive( 'get' )->once()->andReturn( false )
+			->shouldReceive( 'set' )->once();
+
+		$this->assertSame( 'processed text', $this->wp_typo->process( 'text', $is_title, $force_feed, $settings ) );
+	}
+
+	/**
+	 * Tests filter_body_class
+	 *
+	 * @covers ::filter_body_class
+	 */
+	public function test_filter_body_class() {
+		$classes = [ 'foo', 'bar' ];
+
+		$result = $this->wp_typo->filter_body_class( $classes );
+
+		$this->assertSame( $classes, $result );
+		$this->assertAttributeSame( $classes, 'body_classes', $this->wp_typo );
+	}
+
+	/**
+	 * Test set_default_options.
+	 *
+	 * @covers ::set_default_options
+	 *
+	 * @uses ::set_instance
+	 * @uses ::get_default_options
+	 */
+	public function test_set_default_options() {
+		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
+
+		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
+
+		$this->wp_typo->set_default_options();
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test set_default_options.
+	 *
+	 * @covers ::set_default_options
+	 *
+	 * @uses ::set_instance
+	 * @uses ::get_default_options
+	 */
+	public function test_set_default_options_force_defaults() {
+		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
+
+		$this->options->shouldNotReceive( 'get' )->with( Options::RESTORE_DEFAULTS );
+		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
+		$this->options->shouldReceive( 'delete' )->once()->with( Options::RESTORE_DEFAULTS )->andReturn( true );
+		$this->options->shouldReceive( 'delete' )->once()->with( Options::CLEAR_CACHE )->andReturn( true );
+
+		$this->wp_typo->set_default_options( true );
+		$this->assertTrue( true );
+	}
+
+
+	/**
+	 * Test get_default_options.
+	 *
+	 * @covers ::get_default_options
+	 *
+	 * @uses ::set_instance
+	 *
+	 * @runInSeparateProcess
+	 */
+	public function test_get_default_options() {
+		Functions\expect( 'wp_list_pluck' )->once()->with( m::type( 'array' ), 'default' )->andReturn( [ 'bar' => 'foo' ] );
+		Functions\expect( '__' )->atLeast()->once()->andReturn( 'translated_string' );
+
+		$this->assertInternalType( 'array', $this->wp_typo->get_default_options() );
+	}
+
+	/**
+	 * Test clear_cache.
+	 *
+	 * @covers ::clear_cache
+	 */
+	public function test_clear_cache() {
+		$this->transients->shouldReceive( 'invalidate' );
+		$this->cache->shouldReceive( 'invalidate' );
+
+		$this->options->shouldReceive( 'delete' )->once()->with( 'clear_cache' )->andReturn( true );
+
+		$this->wp_typo->clear_cache();
+		$this->assertTrue( true );
+	}
+
+
+	/**
+	 * Test parser_errors_handler.
+	 *
+	 * @covers ::parser_errors_handler
+	 */
+	public function test_parser_errors_handler() {
+		$this->wp_typo->parser_errors_handler( [] );
+		$this->assertTrue( 1 === Filters\applied( 'typo_handle_parser_errors' ) );
+	}
+
+	/**
+	 * Test get_version.
+	 *
+	 * @covers ::get_version
+	 */
+	public function test_get_version() {
+		$this->assertInternalType( 'string', $this->wp_typo->get_version() );
+	}
+
+	/**
+	 * Provide data for testing save_hyphenator_cache_on_shutdown.
+	 *
+	 * @return array
+	 */
+	public function provide_save_hyphenator_cache_on_shutdown_data() {
+		return [
+			[ true,  m::mock( Hyphenator_Cache::class ), true ],
+			[ false, m::mock( Hyphenator_Cache::class ), false ],
+			[ true,  null,                               false ],
+			[ false, null,                               false ],
+		];
+	}
+
+	/**
+	 * Test save_hyphenator_cache_on_shutdown.
+	 *
+	 * @covers ::save_hyphenator_cache_on_shutdown
+	 *
+	 * @dataProvider provide_save_hyphenator_cache_on_shutdown_data
+	 *
+	 * @param bool                  $enable_hyphenation The typo_enable_hyphenation value.
+	 * @param Hyphenator_Cache|null $hyphenator_cache   The hyphenator cache instance.
+	 * @param bool                  $expected           If the hyphenator cache should be saved.
+	 */
+	public function test_save_hyphenator_cache_on_shutdown( $enable_hyphenation, $hyphenator_cache, $expected ) {
+
+		if ( null !== $hyphenator_cache ) {
+			$hyphenator_cache->shouldReceive( 'has_changed' )->andReturn( $expected );
+		}
+
+		$this->setValue( $this->wp_typo, 'hyphenator_cache', $hyphenator_cache );
+
+		if ( $expected ) {
+			$this->transients->shouldReceive( 'cache_object' )->once();
+		} else {
+			$this->transients->shouldReceive( 'cache_object' )->never();
+		}
+
+		$this->wp_typo->save_hyphenator_cache_on_shutdown();
+
+		$this->assertTrue( true );
+	}
+}

--- a/tests/class-wp-typography-singleton-test.php
+++ b/tests/class-wp-typography-singleton-test.php
@@ -38,7 +38,6 @@ use Mockery as m;
  * @coversDefaultClass \WP_Typography
  * @usesDefaultClass \WP_Typography
  *
- * @uses ::__construct
  * @uses ::hash_version_string
  */
 class WP_Typography_Singleton_Test extends TestCase {
@@ -68,8 +67,6 @@ class WP_Typography_Singleton_Test extends TestCase {
 	 * @covers ::get_instance
 	 * @covers ::set_instance
 	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
 	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
 	 * @uses \WP_Typography\Data_Storage\Cache::__construct
 	 * @uses \WP_Typography\Data_Storage\Options::__construct
@@ -98,14 +95,11 @@ class WP_Typography_Singleton_Test extends TestCase {
 			->shouldReceive( 'invalidate' )->byDefault()
 			->getMock();
 
-		$typo = new \WP_Typography( '6.6.6', $transients, $cache, $options );
+		$typo = m::mock( \WP_Typography::class );
 		\WP_Typography::set_instance( $typo );
 
 		$typo2 = \WP_Typography::get_instance();
 		$this->assertSame( $typo, $typo2 );
-
-		$this->assertInstanceOf( \WP_Typography::class, $typo );
-		$this->assertAttributeSame( '6.6.6', 'version', $typo );
 
 		// Check ::get_instance (no underscore).
 		$typo3 = \WP_Typography::get_instance();
@@ -116,9 +110,6 @@ class WP_Typography_Singleton_Test extends TestCase {
 	 * Tests ::get_instance without a previous call to ::_get_instance (i.e. _doing_it_wrong).
 	 *
 	 * @covers ::get_instance
-	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
 	 *
 	 * @expectedException \BadMethodCallException
 	 * @expectedExceptionMessage WP_Typography::get_instance called without prior plugin intialization.
@@ -133,9 +124,6 @@ class WP_Typography_Singleton_Test extends TestCase {
 	 *
 	 * @covers ::set_instance
 	 *
-	 * @uses ::__construct
-	 * @uses ::get_version
-	 *
 	 * @expectedException \BadMethodCallException
 	 * @expectedExceptionMessage WP_Typography::set_instance called more than once.
 	 */
@@ -144,7 +132,7 @@ class WP_Typography_Singleton_Test extends TestCase {
 		$cache      = m::mock( \WP_Typography\Data_Storage\Cache::class );
 		$options    = m::mock( \WP_Typography\Data_Storage\Options::class );
 
-		$typo = new \WP_Typography( '6.6.6', $transients, $cache, $options );
+		$typo = m::mock( \WP_Typography::class );
 		\WP_Typography::set_instance( $typo );
 		\WP_Typography::set_instance( $typo );
 	}

--- a/tests/class-wp-typography-test.php
+++ b/tests/class-wp-typography-test.php
@@ -25,7 +25,6 @@
 namespace WP_Typography\Tests;
 
 use WP_Typography\Data_Storage\Options;
-use WP_Typography\Components\Admin_Interface;
 use WP_Typography\Settings\Plugin_Configuration as Config;
 
 use PHP_Typography\Hyphenator_Cache;
@@ -61,41 +60,6 @@ class WP_Typography_Test extends TestCase {
 	/**
 	 * Test fixture.
 	 *
-	 * @var \WP_Typography\Components\Admin_Interface
-	 */
-	protected $admin_if;
-
-	/**
-	 * Test fixture.
-	 *
-	 * @var \WP_Typography\Components\Public_Interface
-	 */
-	protected $public_if;
-
-	/**
-	 * Test fixture.
-	 *
-	 * @var \WP_Typography\Components\Setup
-	 */
-	protected $setup;
-
-	/**
-	 * Test fixture.
-	 *
-	 * @var \WP_Typography\Components\Multilingual_Support
-	 */
-	protected $multi;
-
-	/**
-	 * Test fixture.
-	 *
-	 * @var \WP_Typography\Components\Common
-	 */
-	protected $common;
-
-	/**
-	 * Test fixture.
-	 *
 	 * @var \WP_Typography\Data_Storage\Transients
 	 */
 	protected $transients;
@@ -120,28 +84,10 @@ class WP_Typography_Test extends TestCase {
 	 */
 	protected function setUp() { // @codingStandardsIgnoreLine
 
-		// Mock WP_Typography\Settings\Multlingual instance.
-		$this->multi = m::mock( \WP_Typography\Components\Multilingual_Support::class )
-			->shouldReceive( 'run' )->byDefault()
-			->shouldReceive( 'filter_defaults' )->andReturnUsing( function( array $defaults ) {
-				return $defaults;
-			} )->byDefault()
-			->getMock();
-
 		// Mock WP_Typography\Data_Storage\Options instance.
 		$this->options = m::mock( \WP_Typography\Data_Storage\Options::class )
 			->shouldReceive( 'get' )->andReturn( false )->byDefault()
 			->shouldReceive( 'set' )->andReturn( false )->byDefault()
-			->getMock();
-
-		// Mock WP_Typography\Components\Setup instance.
-		$this->setup = m::mock( \WP_Typography\Components\Setup::class, [ '/some/path', $this->options ] )
-			->shouldReceive( 'run' )->byDefault()
-			->getMock();
-
-		// Mock WP_Typography\Components\Common instance.
-		$this->common = m::mock( \WP_Typography\Components\Common::class, [ $this->options ] )
-			->shouldReceive( 'run' )->byDefault()
 			->getMock();
 
 		// Mock WP_Typography\Data_Storage\Transients instance.
@@ -159,19 +105,8 @@ class WP_Typography_Test extends TestCase {
 			->shouldReceive( 'invalidate' )->byDefault()
 			->getMock();
 
-		// Mock WP_Typography\Components\Admin_Interface instance.
-		$this->admin_if = m::mock( \WP_Typography\Components\Admin_Interface::class, [ 'plugin_basename', '/plugin/path', $this->options ] )
-			->shouldReceive( 'run' )->byDefault()
-			->shouldReceive( 'get_default_settings' )->andReturn( [ 'dummy_settings' => 'bar' ] )->byDefault()
-			->getMock();
-
-		// Mock WP_Typography\Components\Public_Interface instance.
-		$this->public_if = m::mock( \WP_Typography\Components\Public_Interface::class, [ 'plugin_basename' ] )
-			->shouldReceive( 'run' )->byDefault()
-			->getMock();
-
 		// Create instance.
-		$this->wp_typo = m::mock( \WP_Typography::class, [ '7.7.7', $this->setup, $this->common, $this->admin_if, $this->public_if, $this->multi, $this->transients, $this->cache, $this->options ] )
+		$this->wp_typo = m::mock( \WP_Typography::class, [ '7.7.7', $this->transients, $this->cache, $this->options ] )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 
@@ -195,11 +130,6 @@ class WP_Typography_Test extends TestCase {
 	 * @covers ::__construct
 	 *
 	 * @uses ::get_version
-	 * @uses ::get_version_hash
-	 * @uses \WP_Typography\Components\Admin_Interface::__construct
-	 * @uses \WP_Typography\Components\Public_Interface::__construct
-	 * @uses \WP_Typography\Components\Common::__construct
-	 * @uses \WP_Typography\Components\Setup::__construct
 	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
 	 * @uses \WP_Typography\Data_Storage\Cache::__construct
 	 * @uses \WP_Typography\Data_Storage\Cache::invalidate
@@ -212,11 +142,6 @@ class WP_Typography_Test extends TestCase {
 
 		$typo = new \WP_Typography(
 			'6.6.6',
-			m::mock( \WP_Typography\Components\Setup::class ),
-			m::mock( \WP_Typography\Components\Common::class ),
-			m::mock( \WP_Typography\Components\Admin_Interface::class ),
-			m::mock( \WP_Typography\Components\Public_Interface::class ),
-			m::mock( \WP_Typography\Components\Multilingual_Support::class ),
 			m::mock( \WP_Typography\Data_Storage\Transients::class ),
 			m::mock( \WP_Typography\Data_Storage\Cache::class ),
 			m::mock( \WP_Typography\Data_Storage\Options::class )
@@ -224,28 +149,6 @@ class WP_Typography_Test extends TestCase {
 
 		$this->assertInstanceOf( \WP_Typography::class, $typo );
 		$this->assertAttributeSame( '6.6.6', 'version', $typo );
-	}
-
-	/**
-	 * Tests constructor.
-	 *
-	 * @covers ::run
-	 *
-	 * @uses ::__construct
-	 * @uses ::set_instance
-	 * @uses ::get_version
-	 * @uses ::get_version_hash
-	 * @uses ::hash_version_string
-	 * @uses \WP_Typography\Components\Admin_Interface::__construct
-	 * @uses \WP_Typography\Components\Public_Interface::__construct
-	 * @uses \WP_Typography\Components\Setup::__construct
-	 */
-	public function test_run() {
-		foreach ( [ $this->setup, $this->common, $this->admin_if, $this->public_if, $this->multi ] as $component ) {
-			$component->shouldReceive( 'run' )->once()->with( $this->wp_typo );
-		}
-
-		$this->assertNull( $this->wp_typo->run() );
 	}
 
 	/**
@@ -677,7 +580,6 @@ class WP_Typography_Test extends TestCase {
 	 *
 	 * @covers ::process
 	 *
-	 * @uses ::run
 	 * @uses ::set_instance
 	 *
 	 * @dataProvider provide_process_data
@@ -782,13 +684,10 @@ class WP_Typography_Test extends TestCase {
 	 *
 	 * @covers ::set_default_options
 	 *
-	 * @uses ::run
 	 * @uses ::set_instance
 	 * @uses ::get_default_options
 	 */
 	public function test_set_default_options() {
-		$this->wp_typo->run();
-
 		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
 
 		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
@@ -802,13 +701,10 @@ class WP_Typography_Test extends TestCase {
 	 *
 	 * @covers ::set_default_options
 	 *
-	 * @uses ::run
 	 * @uses ::set_instance
 	 * @uses ::get_default_options
 	 */
 	public function test_set_default_options_force_defaults() {
-		$this->wp_typo->run();
-
 		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
 
 		$this->options->shouldNotReceive( 'get' )->with( Options::RESTORE_DEFAULTS );
@@ -826,18 +722,13 @@ class WP_Typography_Test extends TestCase {
 	 *
 	 * @covers ::get_default_options
 	 *
-	 * @uses ::run
 	 * @uses ::set_instance
 	 *
 	 * @runInSeparateProcess
 	 */
 	public function test_get_default_options() {
-		$this->wp_typo->run();
-
 		Functions\expect( 'wp_list_pluck' )->once()->with( m::type( 'array' ), 'default' )->andReturn( [ 'bar' => 'foo' ] );
 		Functions\expect( '__' )->atLeast()->once()->andReturn( 'translated_string' );
-
-		$this->multi->shouldReceive( 'filter_defaults' )->with( m::type( 'array' ) )->andReturn( [ 'foo' => 'bar' ] );
 
 		$this->assertInternalType( 'array', $this->wp_typo->get_default_options() );
 	}

--- a/tests/class-wp-typography-test.php
+++ b/tests/class-wp-typography-test.php
@@ -41,8 +41,6 @@ use Mockery as m;
  * @coversDefaultClass \WP_Typography
  * @usesDefaultClass \WP_Typography
  *
- * @uses ::__construct
- * @uses ::hash_version_string
  * @uses \WP_Typography\Components\Admin_Interface::__construct
  * @uses \WP_Typography\Components\Public_Interface::__construct
  * @uses \WP_Typography\Components\Setup::__construct
@@ -106,7 +104,7 @@ class WP_Typography_Test extends TestCase {
 			->getMock();
 
 		// Create instance.
-		$this->wp_typo = m::mock( \WP_Typography::class, [ '7.7.7', $this->transients, $this->cache, $this->options ] )
+		$this->wp_typo = m::mock( \WP_Typography\Implementation::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 
@@ -122,33 +120,6 @@ class WP_Typography_Test extends TestCase {
 		$this->setStaticValue( \WP_Typography::class, '_instance', null );
 
 		parent::tearDown();
-	}
-
-	/**
-	 * Tests constructor.
-	 *
-	 * @covers ::__construct
-	 *
-	 * @uses ::get_version
-	 * @uses \WP_Typography\Data_Storage\Abstract_Cache::__construct
-	 * @uses \WP_Typography\Data_Storage\Cache::__construct
-	 * @uses \WP_Typography\Data_Storage\Cache::invalidate
-	 * @uses \WP_Typography\Data_Storage\Options::__construct
-	 * @uses \WP_Typography\Data_Storage\Transients::__construct
-	 * @uses \WP_Typography\Data_Storage\Transients::invalidate
-	 * @uses \WP_Typography\Data_Storage\Transients::get_keys_from_database
-	 */
-	public function test_constructor() {
-
-		$typo = new \WP_Typography(
-			'6.6.6',
-			m::mock( \WP_Typography\Data_Storage\Transients::class ),
-			m::mock( \WP_Typography\Data_Storage\Cache::class ),
-			m::mock( \WP_Typography\Data_Storage\Options::class )
-		);
-
-		$this->assertInstanceOf( \WP_Typography::class, $typo );
-		$this->assertAttributeSame( '6.6.6', 'version', $typo );
 	}
 
 	/**
@@ -174,207 +145,17 @@ class WP_Typography_Test extends TestCase {
 	}
 
 	/**
-	 * Test get_typography_instance.
+	 * Test a static call to get_hyphenation_languages
 	 *
-	 * @covers ::get_typography_instance
-	 */
-	public function test_get_typography_instance() {
-		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
-			Config::ENABLE_HYPHENATION => true,
-		] );
-
-		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
-
-		$this->transients->shouldReceive( 'cache_object' )->twice();
-
-		$this->assertInstanceOf( \PHP_Typography\PHP_Typography::class, $this->invokeMethod( $this->wp_typo, 'get_typography_instance' ) );
-	}
-
-	/**
-	 * Test get_config.
-	 *
-	 * @covers ::get_config
-	 */
-	public function test_get_config() {
-
-		$this->options->shouldReceive( 'get' )->once()->with( Options::CONFIGURATION )->andReturn( [ 'foo' => 'bar' ] );
-
-		$this->assertInternalType( 'array', $this->wp_typo->get_config() );
-	}
-
-	/**
-	 * Test get_config with corrupted option.
-	 *
-	 * @covers ::get_config
-	 */
-	public function test_get_config_corrupted() {
-
-		$this->options->shouldReceive( 'get' )->once()->with( Options::CONFIGURATION )->andReturn( 'wrong' );
-		$this->wp_typo->shouldReceive( 'set_default_options' )->once()->with( true );
-
-		// IRL set_default_options would fix the config object.
-		$this->assertSame( null, $this->wp_typo->get_config() );
-	}
-
-	/**
-	 * Test get_user_settings.
-	 *
-	 * @covers ::get_settings
-	 * @covers ::init_settings_from_options
-	 *
-	 * @uses ::init_settings_from_options
-	 */
-	public function test_get_settings() {
-
-		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
-			Config::IGNORE_TAGS                    => [ 'script' ],
-			Config::IGNORE_CLASSES                 => [ 'noTypo' ],
-			Config::IGNORE_IDS                     => [],
-			Config::SMART_CHARACTERS               => true,
-			Config::SMART_DASHES                   => false,
-			Config::SMART_DASHES_STYLE             => 'international',
-			Config::SMART_ELLIPSES                 => false,
-			Config::SMART_MATH                     => false,
-			Config::SMART_FRACTIONS                => false,
-			Config::SMART_ORDINALS                 => false,
-			Config::SMART_MARKS                    => false,
-			Config::SMART_QUOTES                   => false,
-			Config::SMART_DIACRITICS               => false,
-			Config::DIACRITIC_LANGUAGES            => 'en-US',
-			Config::DIACRITIC_CUSTOM_REPLACEMENTS  => [],
-			Config::SMART_QUOTES_PRIMARY           => 'doubleCurled',
-			Config::SMART_QUOTES_SECONDARY         => 'singleCurled',
-			Config::SINGLE_CHARACTER_WORD_SPACING  => false,
-			Config::DASH_SPACING                   => false,
-			Config::FRACTION_SPACING               => false,
-			Config::UNIT_SPACING                   => false,
-			Config::NUMBERED_ABBREVIATIONS_SPACING => false,
-			Config::FRENCH_PUNCTUATION_SPACING     => false,
-			Config::UNITS                          => [],
-			Config::SPACE_COLLAPSE                 => false,
-			Config::PREVENT_WIDOWS                 => false,
-			Config::WIDOW_MIN_LENGTH               => 2,
-			Config::WIDOW_MAX_PULL                 => 2,
-			Config::WRAP_HYPHENS                   => false,
-			Config::WRAP_EMAILS                    => false,
-			Config::WRAP_URLS                      => false,
-			Config::WRAP_MIN_AFTER                 => 2,
-			Config::STYLE_AMPS                     => false,
-			Config::STYLE_CAPS                     => false,
-			Config::STYLE_NUMBERS                  => false,
-			Config::WRAP_URLS                      => false,
-			Config::STYLE_HANGING_PUNCTUATION      => false,
-			Config::STYLE_INITIAL_QUOTES           => false,
-			Config::INITIAL_QUOTE_TAGS             => [],
-			Config::ENABLE_HYPHENATION             => true,
-			Config::HYPHENATE_HEADINGS             => false,
-			Config::HYPHENATE_CAPS                 => false,
-			Config::HYPHENATE_TITLE_CASE           => false,
-			Config::HYPHENATE_COMPOUNDS            => false,
-			Config::HYPHENATE_LANGUAGES            => 'en-US',
-			Config::HYPHENATE_MIN_LENGTH           => 2,
-			Config::HYPHENATE_MIN_BEFORE           => 2,
-			Config::HYPHENATE_MIN_AFTER            => 2,
-			Config::HYPHENATE_EXCEPTIONS           => [],
-			Config::IGNORE_PARSER_ERRORS           => false,
-			Config::ENABLE_MULTILINGUAL_SUPPORT    => false,
-		] );
-		$this->transients->shouldReceive( 'cache_object' )->once();
-
-		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
-		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
-		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
-
-		$s = $this->wp_typo->get_settings();
-
-		$this->assertInstanceOf( \PHP_Typography\Settings::class, $s );
-	}
-
-	/**
-	 * Test get_user_settings.
-	 *
-	 * @covers ::get_settings
-	 * @covers ::init_settings_from_options
-	 *
-	 * @uses ::init_settings_from_options
-	 */
-	public function test_get_settings_hyphenation_off() {
-
-		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [
-			Config::IGNORE_TAGS                    => [ 'script' ],
-			Config::IGNORE_CLASSES                 => [ 'noTypo' ],
-			Config::IGNORE_IDS                     => [],
-			Config::SMART_CHARACTERS               => false,
-			Config::SMART_DASHES                   => false,
-			Config::SMART_DASHES_STYLE             => 'international',
-			Config::SMART_ELLIPSES                 => false,
-			Config::SMART_MATH                     => false,
-			Config::SMART_FRACTIONS                => false,
-			Config::SMART_ORDINALS                 => false,
-			Config::SMART_MARKS                    => false,
-			Config::SMART_QUOTES                   => false,
-			Config::SMART_DIACRITICS               => false,
-			Config::DIACRITIC_LANGUAGES            => 'en-US',
-			Config::DIACRITIC_CUSTOM_REPLACEMENTS  => [],
-			Config::SMART_QUOTES_PRIMARY           => 'doubleCurled',
-			Config::SMART_QUOTES_SECONDARY         => 'singleCurled',
-			Config::SINGLE_CHARACTER_WORD_SPACING  => false,
-			Config::DASH_SPACING                   => false,
-			Config::FRACTION_SPACING               => false,
-			Config::UNIT_SPACING                   => false,
-			Config::NUMBERED_ABBREVIATIONS_SPACING => false,
-			Config::FRENCH_PUNCTUATION_SPACING     => false,
-			Config::UNITS                          => [],
-			Config::SPACE_COLLAPSE                 => false,
-			Config::PREVENT_WIDOWS                 => false,
-			Config::WIDOW_MIN_LENGTH               => 2,
-			Config::WIDOW_MAX_PULL                 => 2,
-			Config::WRAP_HYPHENS                   => false,
-			Config::WRAP_EMAILS                    => false,
-			Config::WRAP_URLS                      => false,
-			Config::WRAP_MIN_AFTER                 => 2,
-			Config::STYLE_AMPS                     => false,
-			Config::STYLE_CAPS                     => false,
-			Config::STYLE_NUMBERS                  => false,
-			Config::WRAP_URLS                      => false,
-			Config::STYLE_HANGING_PUNCTUATION      => false,
-			Config::STYLE_INITIAL_QUOTES           => false,
-			Config::INITIAL_QUOTE_TAGS             => [],
-			Config::ENABLE_HYPHENATION             => false,
-			Config::HYPHENATE_HEADINGS             => false,
-			Config::HYPHENATE_CAPS                 => false,
-			Config::HYPHENATE_TITLE_CASE           => false,
-			Config::HYPHENATE_COMPOUNDS            => false,
-			Config::HYPHENATE_LANGUAGES            => 'en-US',
-			Config::HYPHENATE_MIN_LENGTH           => 2,
-			Config::HYPHENATE_MIN_BEFORE           => 2,
-			Config::HYPHENATE_MIN_AFTER            => 2,
-			Config::HYPHENATE_EXCEPTIONS           => [],
-			Config::IGNORE_PARSER_ERRORS           => false,
-		] );
-		$this->transients->shouldReceive( 'cache_object' )->once();
-
-		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
-		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
-		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
-
-		$s = $this->wp_typo->get_settings();
-
-		$this->assertInstanceOf( \PHP_Typography\Settings::class, $s );
-	}
-
-	/**
-	 * Test get_hyphenation_languages
-	 *
-	 * @covers ::get_hyphenation_languages
+	 * @covers ::__callStatic
 	 *
 	 * @uses ::get_instance
 	 */
-	public function test_get_hyphenation_languages() {
+	public function test_call_static_get_hyphenation_languages() {
 		// Set up singleton.
 		$this->setStaticValue( \WP_Typography::class, '_instance', $this->wp_typo );
 
-		$this->wp_typo->shouldReceive( 'load_hyphenation_languages' )->once()->andReturn( [ 'de' => 'German' ] );
+		$this->wp_typo->shouldReceive( 'get_hyphenation_languages' )->once()->andReturn( [ 'de' => 'German' ] );
 
 		$langs = \WP_Typography::get_hyphenation_languages();
 
@@ -383,74 +164,22 @@ class WP_Typography_Test extends TestCase {
 	}
 
 	/**
-	 * Test get_diacritic_languages
+	 * Test a static call to foobar(), failing.
 	 *
-	 * @covers ::get_diacritic_languages
+	 * @covers ::__callStatic
 	 *
 	 * @uses ::get_instance
+	 *
+	 * @expectedException \BadMethodCallException
+	 * @expectedExceptionMessage Static method WP_Typography::foobar does not exist.
 	 */
-	public function test_get_diacritic_languages() {
+	public function test_call_static_foobar() {
 		// Set up singleton.
 		$this->setStaticValue( \WP_Typography::class, '_instance', $this->wp_typo );
 
-		$this->wp_typo->shouldReceive( 'load_diacritic_languages' )->once()->andReturn( [ 'de' => 'German' ] );
+		$this->wp_typo->shouldNotReceive( 'foobar' );
 
-		$langs = \WP_Typography::get_diacritic_languages();
-
-		$this->assertContainsOnly( 'string', $langs, 'The languages array should only contain strings.' );
-		$this->assertContainsOnly( 'string', array_keys( $langs ), 'The languages array should be indexed by language codes.' );
-	}
-
-	/**
-	 * Test get_hyphenation_languages
-	 *
-	 * @covers ::load_hyphenation_languages
-	 * @covers ::load_languages
-	 * @covers ::translate_languages
-	 *
-	 * @uses \PHP_Typography\PHP_Typography::get_hyphenation_languages
-	 */
-	public function test_load_hyphenation_languages() {
-		Functions\when( '_x' )->returnArg();
-		if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
-			define( 'WEEK_IN_SECONDS', 999 );
-		}
-
-		$this->cache->shouldReceive( 'get' )->once()->andReturnUsing( function( $key, &$found ) {
-			$found = false;
-			return [];
-		} )->shouldReceive( 'set' )->once();
-
-		$langs = $this->wp_typo->load_hyphenation_languages();
-
-		$this->assertContainsOnly( 'string', $langs, 'The languages array should only contain strings.' );
-		$this->assertContainsOnly( 'string', array_keys( $langs ), 'The languages array should be indexed by language codes.' );
-	}
-
-	/**
-	 * Test get_hyphenation_languages
-	 *
-	 * @covers ::load_diacritic_languages
-	 * @covers ::load_languages
-	 * @covers ::translate_languages
-	 *
-	 * @uses \PHP_Typography\PHP_Typography::get_hyphenation_languages
-	 */
-	public function test_load_diacritic_languages() {
-		Functions\when( '_x' )->returnArg();
-		if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
-			define( 'WEEK_IN_SECONDS', 999 );
-		}
-
-		$this->cache->shouldReceive( 'get' )->once()->andReturnUsing( function( $key, &$found ) {
-			$found = false;
-			return [];
-		} )->shouldReceive( 'set' )->once();
-
-		$langs = $this->wp_typo->load_diacritic_languages();
-
-		$this->assertContainsOnly( 'string', $langs, 'The languages array should only contain strings.' );
-		$this->assertContainsOnly( 'string', array_keys( $langs ), 'The languages array should be indexed by language codes.' );
+		$this->assertNull( \WP_Typography::foobar() );
 	}
 
 	/**
@@ -514,258 +243,8 @@ class WP_Typography_Test extends TestCase {
 	 */
 	public function test_filter_feed_title() {
 		$this->setStaticValue( \WP_Typography::class, '_instance', $this->wp_typo );
-		$this->wp_typo->shouldReceive( 'process_feed' )->once()->with( 'foobar', true, null )->andReturn( 'barfoo' );
+		$this->wp_typo->shouldReceive( 'process_feed_title' )->once()->with( 'foobar', null )->andReturn( 'barfoo' );
 		$this->assertSame( 'barfoo', \WP_Typography::filter_feed_title( 'foobar', null ) );
-	}
-
-	/**
-	 * Test process_title.
-	 *
-	 * @covers ::process_title
-	 */
-	public function test_process_title() {
-		$this->wp_typo->shouldReceive( 'process' )->once()->with( 'foobar', true, false, null )->andReturn( 'barfoo' );
-
-		$this->assertSame( 'barfoo', $this->wp_typo->process_title( 'foobar', null ) );
-	}
-
-	/**
-	 * Test process_feed.
-	 *
-	 * @covers ::process_feed
-	 */
-	public function test_process_feed() {
-		$this->wp_typo->shouldReceive( 'process' )->once()->with( 'foobar', true, true, null )->andReturn( 'barfoo' );
-
-		$this->assertSame( 'barfoo', $this->wp_typo->process_feed( 'foobar', true, null ) );
-	}
-
-	/**
-	 * Test process_title_parts.
-	 *
-	 * @covers ::process_title_parts
-	 */
-	public function test_process_title_parts() {
-		$title_parts = [
-			'fo' . \PHP_Typography\U::SOFT_HYPHEN . 'o',
-			'bar',
-			'baz',
-		];
-
-		foreach ( $title_parts as $part ) {
-			$this->wp_typo->shouldReceive( 'process' )->once()->with( $part, true, true, null )->andReturn( $part . $part );
-		}
-
-		$this->assertSame( [ 'foofoo', 'barbar', 'bazbaz' ], $this->wp_typo->process_title_parts( $title_parts, null ) );
-	}
-
-	/**
-	 * Provide data for testing process.
-	 *
-	 * @return array
-	 */
-	public function provide_process_data() {
-		return [
-			[ true, true, true, null ],
-			[ false, false, false, null ],
-			[ false, true, false, null ],
-			[ false, false, true, null ],
-			[ true, false, true, null ],
-			[ false, false, false, m::mock( \PHP_Typography\Settings::class )->shouldReceive( 'get_hash' )->andReturn( 'another_fake_hash' )->getMock() ],
-		];
-	}
-
-	/**
-	 * Test process
-	 *
-	 * @covers ::process
-	 *
-	 * @uses ::set_instance
-	 *
-	 * @dataProvider provide_process_data
-	 *
-	 * @param  bool     $is_title   Fragment is a title.
-	 * @param  bool     $force_feed Enforce feed processing.
-	 * @param  bool     $is_feed    Value for is_feed().
-	 * @param  Settings $settings   May be null.
-	 */
-	public function test_process( $is_title, $force_feed, $is_feed, $settings = null ) {
-		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
-			define( 'DAY_IN_SECONDS', 999 );
-		}
-
-		Functions\expect( 'is_feed' )->andReturn( $is_feed );
-
-		if ( null === $settings ) {
-			$settings_mock = m::mock( \PHP_Typography\Settings::class )->shouldReceive( 'get_hash' )->andReturn( 'another_fake_hash' )->getMock();
-
-			$this->wp_typo->shouldReceive( 'get_settings' )->once()->andReturn( $settings_mock );
-		}
-
-		// Fake filter_body_classes.
-		$this->setValue( $this->wp_typo, 'body_classes', [ 'foo', 'bar' ], \WP_Typography::class );
-
-		Filters\expectApplied( 'typo_settings' )->once()->with( m::type( \PHP_Typography\Settings::class ) )->andReturnFirstArg();
-		Filters\expectApplied( 'typo_processed_text_caching_duration' )->once()->with( m::type( 'int' ) )->andReturn( 5 );
-
-		$typo_mock = m::mock( \PHP_Typography\PHP_Typography::class );
-		$this->wp_typo->shouldReceive( 'get_typography_instance' )->once()->andReturn( $typo_mock );
-		if ( $is_feed || $force_feed ) {
-			$typo_mock->shouldReceive( 'process_feed' )->once()->with( 'text', m::type( \PHP_Typography\Settings::class ), $is_title, [ 'foo', 'bar' ] )->andReturn( 'processed text' );
-		} else {
-			$typo_mock->shouldReceive( 'process' )->once()->with( 'text', m::type( \PHP_Typography\Settings::class ), $is_title, [ 'foo', 'bar' ] )->andReturn( 'processed text' );
-		}
-
-		$this->cache
-			->shouldReceive( 'get' )->once()->andReturn( false )
-			->shouldReceive( 'set' )->once();
-
-		$this->assertSame( 'processed text', $this->wp_typo->process( 'text', $is_title, $force_feed, $settings ) );
-	}
-
-	/**
-	 * Test set_transient.
-	 *
-	 * @covers ::set_transient
-	 */
-	public function foo_test_set_transient() {
-		Functions\expect( 'set_transient' )->once()->with( 'my_transient', 'my_value', 666 )->andReturn( true );
-		Functions\expect( 'update_option' )->once()->with( 'typo_transient_keys', [
-			'my_transient' => true,
-		] )->andReturn( true );
-		$this->assertTrue( $this->wp_typo->set_transient( 'my_transient', 'my_value', 666 ) );
-
-		Functions\expect( 'set_transient' )->once()->with( 'my_other_transient', 'my_value', 666 )->andReturn( true );
-		Functions\expect( 'update_option' )->once()->with( 'typo_transient_keys', [
-			'my_transient'       => true,
-			'my_other_transient' => true,
-		] )->andReturn( true );
-		$this->assertTrue( $this->wp_typo->set_transient( 'my_other_transient', 'my_value', 666 ) );
-
-		Functions\expect( 'set_transient' )->once()->with( 'my_third_transient', 'my_value', 666 )->andReturn( false );
-		$this->assertFalse( $this->wp_typo->set_transient( 'my_third_transient', 'my_value', 666 ) );
-	}
-
-	/**
-	 * Test set_cache.
-	 *
-	 * @covers ::set_cache
-	 */
-	public function foo_test_set_cache() {
-		Functions\expect( 'wp_cache_set' )->once()->with( 'my_cache_key', 'my_value', 'wp-typography', 666 )->andReturn( true );
-		Functions\expect( 'update_option' )->once()->with( 'typo_cache_keys', [
-			'my_cache_key' => true,
-		] )->andReturn( true );
-		$this->assertTrue( $this->wp_typo->set_cache( 'my_cache_key', 'my_value', 666 ) );
-
-		Functions\expect( 'wp_cache_set' )->once()->with( 'my_other_cache_key', 'my_value', 'wp-typography', 666 )->andReturn( true );
-		Functions\expect( 'update_option' )->once()->with( 'typo_cache_keys', [
-			'my_cache_key'       => true,
-			'my_other_cache_key' => true,
-		] )->andReturn( true );
-		$this->assertTrue( $this->wp_typo->set_cache( 'my_other_cache_key', 'my_value', 666 ) );
-
-		Functions\expect( 'wp_cache_set' )->once()->with( 'my_third_cache_key', 'my_value', 'wp-typography', 666 )->andReturn( false );
-		$this->assertFalse( $this->wp_typo->set_cache( 'my_third_cache_key', 'my_value', 666 ) );
-	}
-
-	/**
-	 * Test get_cache.
-	 *
-	 * @covers ::get_cache
-	 */
-	public function foo_test_get_cache() {
-		Functions\expect( 'wp_cache_get' )->once()->with( 'my_cache_key', 'wp-typography', false, false )->andReturn( 'foo' );
-		$this->assertSame( 'foo', $this->wp_typo->get_cache( 'my_cache_key', $found ) );
-	}
-
-	/**
-	 * Test set_default_options.
-	 *
-	 * @covers ::set_default_options
-	 *
-	 * @uses ::set_instance
-	 * @uses ::get_default_options
-	 */
-	public function test_set_default_options() {
-		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
-
-		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
-
-		$this->wp_typo->set_default_options();
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * Test set_default_options.
-	 *
-	 * @covers ::set_default_options
-	 *
-	 * @uses ::set_instance
-	 * @uses ::get_default_options
-	 */
-	public function test_set_default_options_force_defaults() {
-		$this->wp_typo->shouldReceive( 'get_default_options' )->once()->andReturn( [ 'foo' => 'bar' ] );
-
-		$this->options->shouldNotReceive( 'get' )->with( Options::RESTORE_DEFAULTS );
-		$this->options->shouldReceive( 'set' )->once()->with( Options::CONFIGURATION, m::type( 'array' ) );
-		$this->options->shouldReceive( 'delete' )->once()->with( Options::RESTORE_DEFAULTS )->andReturn( true );
-		$this->options->shouldReceive( 'delete' )->once()->with( Options::CLEAR_CACHE )->andReturn( true );
-
-		$this->wp_typo->set_default_options( true );
-		$this->assertTrue( true );
-	}
-
-
-	/**
-	 * Test get_default_options.
-	 *
-	 * @covers ::get_default_options
-	 *
-	 * @uses ::set_instance
-	 *
-	 * @runInSeparateProcess
-	 */
-	public function test_get_default_options() {
-		Functions\expect( 'wp_list_pluck' )->once()->with( m::type( 'array' ), 'default' )->andReturn( [ 'bar' => 'foo' ] );
-		Functions\expect( '__' )->atLeast()->once()->andReturn( 'translated_string' );
-
-		$this->assertInternalType( 'array', $this->wp_typo->get_default_options() );
-	}
-
-	/**
-	 * Test clear_cache.
-	 *
-	 * @covers ::clear_cache
-	 */
-	public function test_clear_cache() {
-		$this->transients->shouldReceive( 'invalidate' );
-		$this->cache->shouldReceive( 'invalidate' );
-
-		$this->options->shouldReceive( 'delete' )->once()->with( 'clear_cache' )->andReturn( true );
-
-		$this->wp_typo->clear_cache();
-		$this->assertTrue( true );
-	}
-
-
-	/**
-	 * Test parser_errors_handler.
-	 *
-	 * @covers ::parser_errors_handler
-	 */
-	public function test_parser_errors_handler() {
-		$this->wp_typo->parser_errors_handler( [] );
-		$this->assertTrue( 1 === Filters\applied( 'typo_handle_parser_errors' ) );
-	}
-
-	/**
-	 * Test get_version.
-	 *
-	 * @covers ::get_version
-	 */
-	public function test_get_version() {
-		$this->assertInternalType( 'string', $this->wp_typo->get_version() );
 	}
 
 	/**
@@ -773,52 +252,14 @@ class WP_Typography_Test extends TestCase {
 	 *
 	 * @covers ::get_version_hash
 	 * @covers ::hash_version_string
+	 *
+	 * @uses ::__callStatic
 	 */
 	public function test_get_version_hash() {
-		$this->assertInternalType( 'string', $this->wp_typo->get_version_hash() );
+		$this->setStaticValue( \WP_Typography::class, '_instance', $this->wp_typo );
+		$this->wp_typo->shouldReceive( 'get_version' )->once()->andReturn( '7.6.6' );
+
+		$this->assertSame( 'GFF', $this->wp_typo->get_version_hash() );
 	}
 
-	/**
-	 * Provide data for testing save_hyphenator_cache_on_shutdown.
-	 *
-	 * @return array
-	 */
-	public function provide_save_hyphenator_cache_on_shutdown_data() {
-		return [
-			[ true,  m::mock( Hyphenator_Cache::class ), true ],
-			[ false, m::mock( Hyphenator_Cache::class ), false ],
-			[ true,  null,                               false ],
-			[ false, null,                               false ],
-		];
-	}
-
-	/**
-	 * Test save_hyphenator_cache_on_shutdown.
-	 *
-	 * @covers ::save_hyphenator_cache_on_shutdown
-	 *
-	 * @dataProvider provide_save_hyphenator_cache_on_shutdown_data
-	 *
-	 * @param bool                  $enable_hyphenation The typo_enable_hyphenation value.
-	 * @param Hyphenator_Cache|null $hyphenator_cache   The hyphenator cache instance.
-	 * @param bool                  $expected           If the hyphenator cache should be saved.
-	 */
-	public function test_save_hyphenator_cache_on_shutdown( $enable_hyphenation, $hyphenator_cache, $expected ) {
-
-		if ( null !== $hyphenator_cache ) {
-			$hyphenator_cache->shouldReceive( 'has_changed' )->andReturn( $expected );
-		}
-
-		$this->setValue( $this->wp_typo, 'hyphenator_cache', $hyphenator_cache );
-
-		if ( $expected ) {
-			$this->transients->shouldReceive( 'cache_object' )->once();
-		} else {
-			$this->transients->shouldReceive( 'cache_object' )->never();
-		}
-
-		$this->wp_typo->save_hyphenator_cache_on_shutdown();
-
-		$this->assertTrue( true );
-	}
 }

--- a/tests/components/class-admin-interface-test.php
+++ b/tests/components/class-admin-interface-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2018 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -117,7 +117,7 @@ class Admin_Interface_Test extends TestCase {
 		$this->admin = m::mock( Admin_Interface::class, [ 'plugin/basename', 'plugin/plugin.php', $this->options ] )
 			->shouldAllowMockingProtectedMethods()->makePartial();
 
-		$this->plugin = m::mock( \WP_Typography::class )->shouldReceive( 'get_version' )->andReturn( '6.6.6' )->byDefault()->getMock();
+		$this->plugin = m::mock( \WP_Typography\Implementation::class )->shouldReceive( 'get_version' )->andReturn( '6.6.6' )->byDefault()->getMock();
 
 		$this->admin_form_controls = [
 			Config::HYPHENATE_LANGUAGES => m::mock( UI\Select::class ),
@@ -187,8 +187,8 @@ class Admin_Interface_Test extends TestCase {
 		$this->admin_form_controls[ Config::HYPHENATE_LANGUAGES ]->shouldReceive( 'set_option_values' )->once()->with( m::type( 'array' ) );
 		$this->admin_form_controls[ Config::DIACRITIC_LANGUAGES ]->shouldReceive( 'set_option_values' )->once()->with( m::type( 'array' ) );
 
-		$this->plugin->shouldReceive( 'load_hyphenation_languages' )->andReturn( [ 'CODE' => 'Language' ] );
-		$this->plugin->shouldReceive( 'load_diacritic_languages' )->andReturn( [ 'CODE' => 'Language' ] );
+		$this->plugin->shouldReceive( 'get_hyphenation_languages' )->andReturn( [ 'CODE' => 'Language' ] );
+		$this->plugin->shouldReceive( 'get_diacritic_languages' )->andReturn( [ 'CODE' => 'Language' ] );
 
 		$this->expectOutputString( 'SETTINGS_PHP' );
 

--- a/tests/components/class-multilingual-support-test.php
+++ b/tests/components/class-multilingual-support-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2018 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -78,7 +78,7 @@ class Multilingual_Support_Test extends TestCase {
 	protected function setUp() { // @codingStandardsIgnoreLine
 		parent::setUp();
 
-		$this->plugin = m::mock( \WP_Typography::class )
+		$this->plugin = m::mock( \WP_Typography\Implementation::class )
 			->shouldReceive( 'get_version' )->andReturn( '6.6.6' )->byDefault()
 			->getMock()->makePartial();
 
@@ -139,8 +139,8 @@ class Multilingual_Support_Test extends TestCase {
 	 */
 	public function test_add_plugin_defaults_filter() {
 
-		$this->plugin->shouldReceive( 'load_hyphenation_languages' )->once()->andReturn( [ 'de' => 'Deutsch' ] );
-		$this->plugin->shouldReceive( 'load_diacritic_languages' )->once()->andReturn( [ 'en' => 'English' ] );
+		$this->plugin->shouldReceive( 'get_hyphenation_languages' )->once()->andReturn( [ 'de' => 'Deutsch' ] );
+		$this->plugin->shouldReceive( 'get_diacritic_languages' )->once()->andReturn( [ 'en' => 'English' ] );
 
 		Filters\expectAdded( 'typo_plugin_defaults' )->once()->with( [ $this->multi, 'filter_defaults' ] );
 

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -67,7 +67,7 @@ function run_wp_typography() {
 		require_once __DIR__ . '/vendor/autoload.php';
 
 		// Create the plugin.
-		$plugin = WP_Typography_Factory::get( __FILE__ )->create( 'WP_Typography' );
+		$plugin = WP_Typography_Factory::get( __FILE__ )->create( 'WP_Typography\Plugin_Controller' );
 
 		// Start the plugin for real.
 		$plugin->run();


### PR DESCRIPTION
Fixes #196.

Changes proposed in this pull request:
- `WP_Typography` becomes a pure facade for the `PHP_Typography` API.
- Deprecate the static wrapper functions in favor of magic method overriding (e.g. allowing `process` to be called statically).
- Move implementation to new class `WP_Typography\Implementation` to allow static and non-static calls to the same method names.
