### PR TITLE
Add hooks to allow for custom node manipulation

### DIFF
--- a/includes/wp-typography/class-implementation.php
+++ b/includes/wp-typography/class-implementation.php
@@ -450,10 +450,7 @@ class Implementation extends \WP_Typography {
 
 			if ( ! $typo instanceof PHP_Typography ) {
 				// OK, we have to initialize the PHP_Typography instance manually.
-				$typo = new PHP_Typography();
-
-				// Ensure that all fixes are pre-initialized.
-				$typo->get_registry();
+				$typo = new PHP_Typography( new Typography\Custom_Registry() );
 
 				// Try again next time.
 				$this->transients->cache_object( $transient, $typo, 'typography' );

--- a/includes/wp-typography/typography/class-custom-node-fix.php
+++ b/includes/wp-typography/typography/class-custom-node-fix.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Typography;
+
+use PHP_Typography\Settings;
+use PHP_Typography\Fixes\Node_Fixes\Abstract_Node_Fix;
+
+/**
+ * A node fix with WordPress hooks.
+ *
+ * @since 5.4.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Custom_Node_Fix extends Abstract_Node_Fix {
+
+	/**
+	 * The group part of the filter hook.
+	 *
+	 * @var string
+	 */
+	private $group;
+
+	/**
+	 * Creates a new fix instance.
+	 *
+	 * @param string $group The fix group used in the hook.
+	 */
+	public function __construct( $group ) {
+		parent::__construct( true );
+
+		$this->group = $group;
+	}
+
+
+	/**
+	 * Apply the fix to a given textnode.
+	 *
+	 * @param \DOMText $textnode Required.
+	 * @param Settings $settings Required.
+	 * @param bool     $is_title Optional. Default false.
+	 *
+	 * @return void
+	 */
+	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+		/**
+		 * Filters the text node content for the given group.
+		 *
+		 * @param string   $content  The textnode data.
+		 * @param \DOMText $textnode The processed node.
+		 * @param Settings $settings The typography settings to apply.
+		 * @param bool     $is_title Whether the content occurs in a title/heading context.
+		 */
+		$textnode->data = \apply_filters( "typo_custom_{$this->group}_node_fix", $textnode->data, $textnode, $settings, $is_title );
+	}
+}

--- a/includes/wp-typography/typography/class-custom-registry.php
+++ b/includes/wp-typography/typography/class-custom-registry.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Typography;
+
+use PHP_Typography\Fixes\Default_Registry;
+use PHP_Typography\Hyphenator\Cache;
+
+/**
+ * An extension of the default PHP-Typography registry.
+ *
+ * @since 5.4.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Custom_Registry extends Default_Registry {
+
+	/**
+	 * Creates new registry instance with custom fixes.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		// Register additional node fixes.
+		$this->register_node_fix( new Custom_Node_Fix( 'characters' ), self::CHARACTERS );
+		$this->register_node_fix( new Custom_Node_Fix( 'spacing_pre' ), self::SPACING_PRE_WORDS );
+		$this->register_node_fix( new Custom_Node_Fix( 'spacing_post' ), self::SPACING_POST_WORDS );
+		$this->register_node_fix( new Custom_Node_Fix( 'html_insertion' ), self::HTML_INSERTION );
+
+		// Register additional token fix.
+		$this->register_token_fix( new Custom_Token_Fix( 'mixed_words' ) );
+		$this->register_token_fix( new Custom_Token_Fix( 'compound_words' ) );
+		$this->register_token_fix( new Custom_Token_Fix( 'words' ) );
+		$this->register_token_fix( new Custom_Token_Fix( 'other' ) );
+	}
+}

--- a/includes/wp-typography/typography/class-custom-token-fix.php
+++ b/includes/wp-typography/typography/class-custom-token-fix.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/wp-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Typography;
+
+use PHP_Typography\Settings;
+
+use PHP_Typography\Text_Parser\Token;
+
+use PHP_Typography\Fixes\Token_Fixes\Abstract_Token_Fix;
+
+/**
+ * A token fix with WordPress hooks.
+ *
+ * @since 5.4.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Custom_Token_Fix extends Abstract_Token_Fix {
+
+	/**
+	 * The token type part of the filter hook.
+	 *
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * Creates a new fix instance.
+	 *
+	 * @param string $type The word type targetted by the fix, i.e. either `mixed_words`, 'compound_words`, `words`, or `other`.
+	 *
+	 * @throws \InvalidArgumentException The exception is thrown if `$type` is any other string.
+	 */
+	public function __construct( $type ) {
+		$valid_types = [
+			'mixed_words'    => self::MIXED_WORDS,
+			'compound_words' => self::COMPOUND_WORDS,
+			'words'          => self::WORDS,
+			'other'          => self::OTHER,
+		];
+
+		if ( ! isset( $valid_types[ $type ] ) ) {
+			throw new \InvalidArgumentException( "$type is not a valid word type." );
+		}
+
+		parent::__construct( $valid_types[ $type ], true );
+
+		$this->type = $type;
+	}
+
+
+	/**
+	 * Apply the tweak to a given textnode.
+	 *
+	 * @param Token[]       $tokens   Required.
+	 * @param Settings      $settings Required.
+	 * @param bool          $is_title Optional. Default false.
+	 * @param \DOMText|null $textnode Optional. Default null.
+	 *
+	 * @return Token[] An array of tokens.
+	 */
+	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+
+		/**
+		 * Filters the tokenized text node content (limited to a certain "word" type).
+		 *
+		 * @param Token[]  $tokens   The relevant "words" of the tokenized content.
+		 * @param \DOMText $textnode The processed node.
+		 * @param Settings $settings The typography settings to apply.
+		 * @param bool     $is_title Whether the content occurs in a title/heading context.
+		 */
+		return \apply_filters( "typo_custom_{$this->type}_token_fix", $tokens, $textnode, $settings, $is_title );
+	}
+}

--- a/tests/class-wp-typography-implementation-test.php
+++ b/tests/class-wp-typography-implementation-test.php
@@ -150,6 +150,10 @@ class WP_Typography_Implementation_Test extends TestCase {
 	 * Test get_typography_instance.
 	 *
 	 * @covers ::get_typography_instance
+	 *
+	 * @uses \WP_Typography\Typography\Custom_Node_Fix::__construct
+	 * @uses \WP_Typography\Typography\Custom_Registry::__construct
+	 * @uses \WP_Typography\Typography\Custom_Token_Fix::__construct
 	 */
 	public function test_get_typography_instance() {
 		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn( [

--- a/tests/typography/class-custom-node-fix-test.php
+++ b/tests/typography/class-custom-node-fix-test.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or ( at your option ) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  @package mundschenk-at/wp-typography/tests
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests\Typography;
+
+use WP_Typography\Typography\Custom_Node_Fix;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+/**
+ * Custom_Node_Fix unit test.
+ *
+ * @coversDefaultClass \WP_Typography\Typography\Custom_Node_Fix
+ * @usesDefaultClass \WP_Typography\Typography\Custom_Node_Fix
+ */
+class Custom_Node_Fix_Test extends \WP_Typography\Tests\TestCase {
+
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() { // @codingStandardsIgnoreLine
+		parent::setUp();
+	}
+
+	/**
+	 * Necesssary clean-up work.
+	 */
+	protected function tearDown() { // @codingStandardsIgnoreLine
+		parent::tearDown();
+	}
+
+	/**
+	 * Test the constructor.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses PHP_Typography\Fixes\Node_Fixes\Abstract_Node_Fix::__construct
+	 */
+	public function test_constructor() {
+		$fix = new Custom_Node_Fix( 'foobar' );
+
+		$this->assertAttributeSame( 'foobar', 'group', $fix );
+	}
+
+	/**
+	 * Test apply function.
+	 *
+	 * @covers ::apply
+	 *
+	 * @uses ::__construct
+	 */
+	public function test_apply() {
+		$group   = 'foobar';
+		$fix     = new Custom_Node_Fix( $group );
+		$s       = m::mock( \PHP_Typography\Settings::class );
+		$element = new \DOMElement( 'foo', 'content' );
+		$node    = $element->firstChild;
+
+		Filters\expectApplied( "typo_custom_{$group}_node_fix" )
+			->once()
+			->with( 'content', $node, $s, false )
+			->andReturn( 'filtered_content' );
+
+		$fix->apply( $node, $s, false );
+
+		$this->assertSame( 'filtered_content', $node->data );
+	}
+}

--- a/tests/typography/class-custom-registry-test.php
+++ b/tests/typography/class-custom-registry-test.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or ( at your option ) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  @package mundschenk-at/wp-typography/tests
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests\Typography;
+
+use WP_Typography\Typography\Custom_Registry;
+use WP_Typography\Typography\Custom_Node_Fix;
+use WP_Typography\Typography\Custom_Token_Fix;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+/**
+ * Custom_Registry unit test.
+ *
+ * @coversDefaultClass \WP_Typography\Typography\Custom_Registry
+ * @usesDefaultClass \WP_Typography\Typography\Custom_Registry
+ */
+class Custom_Registry_Test extends \WP_Typography\Tests\TestCase {
+
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() { // @codingStandardsIgnoreLine
+		parent::setUp();
+	}
+
+	/**
+	 * Necesssary clean-up work.
+	 */
+	protected function tearDown() { // @codingStandardsIgnoreLine
+		parent::tearDown();
+	}
+
+	/**
+	 * Test constructor.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses WP_Typography\Typography\Custom_Node_Fix::__construct
+	 * @uses WP_Typography\Typography\Custom_Token_Fix::__construct
+	 * @uses PHP_Typography\Fixes\Token_fixes\Abstract_Token_Fix::__construct
+	 */
+	public function test_constructor() {
+		$registry = m::mock( Custom_Registry::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial()
+			->shouldReceive( 'register_node_fix' )->times( 4 )->with( m::type( Custom_Node_Fix::class ), m::type( 'int' ) )
+			->shouldReceive( 'register_token_fix' )->times( 4 )->with( m::type( Custom_Token_Fix::class ) )
+			->getMock();
+
+		$registry->__construct();
+
+		$this->assertInstanceOf( Custom_Registry::class, $registry );
+	}
+
+}

--- a/tests/typography/class-custom-token-fix-test.php
+++ b/tests/typography/class-custom-token-fix-test.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ *  This file is part of wp-Typography.
+ *
+ *  Copyright 2018 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or ( at your option ) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  @package mundschenk-at/wp-typography/tests
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests\Typography;
+
+use WP_Typography\Typography\Custom_Token_Fix;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use Mockery as m;
+
+/**
+ * Custom_Token_Fix unit test.
+ *
+ * @coversDefaultClass \WP_Typography\Typography\Custom_Token_Fix
+ * @usesDefaultClass \WP_Typography\Typography\Custom_Token_Fix
+ */
+class Custom_Token_Fix_Test extends \WP_Typography\Tests\TestCase {
+
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp() { // @codingStandardsIgnoreLine
+		parent::setUp();
+	}
+
+	/**
+	 * Necesssary clean-up work.
+	 */
+	protected function tearDown() { // @codingStandardsIgnoreLine
+		parent::tearDown();
+	}
+
+	/**
+	 * Test get_defaults static method called twice.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses PHP_Typography\Fixes\Token_fixes\Abstract_Token_Fix::__construct
+	 */
+	public function test_constructor() {
+		$fix = new Custom_Token_Fix( 'words' );
+
+		$this->assertAttributeSame( 'words', 'type', $fix );
+	}
+
+	/**
+	 * Test get_defaults static method called twice.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @uses PHP_Typography\Fixes\Token_fixes\Abstract_Token_Fix::__construct
+	 */
+	public function test_constructor_invalid() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$fix = new Custom_Token_Fix( 'foobar' );
+	}
+
+	/**
+	 * Test apply function.
+	 *
+	 * @covers ::apply
+	 *
+	 * @uses ::__construct
+	 */
+	public function test_apply() {
+		$type    = 'compound_words';
+		$fix     = new Custom_Token_Fix( $type );
+		$s       = m::mock( \PHP_Typography\Settings::class );
+		$element = new \DOMElement( 'foo', 'content' );
+		$node    = $element->firstChild;
+
+		Filters\expectApplied( "typo_custom_{$type}_token_fix" )
+			->once()
+			->with( [], $node, $s, false )
+			->andReturn( [] );
+
+		$this->assertSame( [], $fix->apply( [], $s, false, $node ) );
+	}
+}


### PR DESCRIPTION
Fixes #217, fixes #218.

Changes proposed in this pull request:
- New filter hooks `typo_custom_{$group}_node_fix` for custom node fixes.
- New filter hook `typo_custom_token_fix` for custom token fixes.-