### PR TITLE
No content filtering while running WP-CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 *   _Feature_: The list of smart quotes exceptions (words beginning with apostrophes) can now be customized.
 *   _Feature_: HTML5 parser performance hugely improved (up to 11× faster).
 *   _Change_: xxx
+*   _Bugfix_: Output filtering is now suspended during WP-CLI commands.
 *   _Bugfix_: Unit spacing is now properly applied to monetary symbols ($, €, etc.).
 *   _Bugfix_: Certain HTML entities (e.g. `&amp;`) were accidentally dropped in rare cases.
 *   _Bugfix_: Comply with the new WordPress Coding Standards 2.0.

--- a/includes/wp-typography/components/class-public-interface.php
+++ b/includes/wp-typography/components/class-public-interface.php
@@ -89,8 +89,8 @@ class Public_Interface implements Plugin_Component {
 	public function run( \WP_Typography $plugin ) {
 		$this->plugin = $plugin;
 
-		if ( ! \is_admin() ) {
-			// Load settings.
+		// Do not run our filters on the admin side or during a WP-CLI command.
+		if ( ! \is_admin() && ! defined( 'WP_CLI' ) ) {
 			\add_action( 'init', [ $this, 'init' ] );
 		}
 	}

--- a/includes/wp-typography/integration/class-container.php
+++ b/includes/wp-typography/integration/class-container.php
@@ -75,6 +75,7 @@ class Container {
 			}
 		}
 
+		// No need to restrict these to the frontend, that's already done by Public_Interface.
 		\add_filter( 'typo_content_filters', [ $this, 'get_content_filters' ] );
 	}
 


### PR DESCRIPTION
Fixes #229.

Changes proposed in this pull request:
- Content filters are disabled during WP-CLI commands.