### PR TITLE
Release 5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 5.5.1 - January 27, 2019
+*   _Bugfix_: Parts of hyphenated words should not be detected as Roman numerals anymore.
+*   _Bugfix_: The Unicode hyphen character (‐) is recognized as a valid word combiner.
+
 ## 5.5.0 - January 27, 2019
 *   _Feature_: French (1<sup>ère</sup>) and "Latin" (1<sup>o</sup>) ordinal numbers are now supported by the smart ordinals feature (also with Roman numerals, e.g. XIX<sup>ème</sup>).
 *   _Feature_: The list of smart quotes exceptions (words beginning with apostrophes) can now be customized.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 
     "require": {
         "php": ">=5.6.0",
-        "mundschenk-at/php-typography": "^6.4",
+        "mundschenk-at/php-typography": "^6.4.2",
         "level-2/dice": "^2.0.3",
         "mundschenk-at/check-wp-requirements": "^1.0",
         "mundschenk-at/wp-data-storage": "^1.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: typography, hyphenation, smart quotes, formatting, widows, orphans, typogr
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 5.0
-Stable tag: 5.5.0
+Stable tag: 5.5.1
 
 Improve your web typography with: hyphenation, space control, intelligent character replacement, and CSS hooks.
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,10 @@ please upgrade PHP or continue to use version 4.2.2.
 
 == Changelog ==
 
+= 5.5.1 - January 27, 2019 =
+* _Bugfix_: Parts of hyphenated words should not be detected as Roman numerals anymore.
+* _Bugfix_: The Unicode hyphen character (‐) is recognized as a valid word combiner.
+
 = 5.5.0 - January 27, 2019 =
 * _Feature_: French (1<sup>ère</sup>) and "Latin" (1<sup>o</sup>) ordinal numbers are now supported by the smart ordinals feature (also with Roman numerals, e.g. XIX<sup>ème</sup>).
 * _Feature_: The list of smart quotes exceptions (words beginning with apostrophes) can now be customized.

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -29,7 +29,7 @@
  *  Description: Improve your web typography with: hyphenation, space control, intelligent character replacement, and CSS hooks.
  *  Author: Peter Putzer
  *  Author URI: https://code.mundschenk.at
- *  Version: 5.5.0
+ *  Version: 5.5.1
  *  License: GNU General Public License v2 or later
  *  License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *  Text Domain: wp-typography


### PR DESCRIPTION
Changes proposed in this pull request:
*   _Bugfix_: Parts of hyphenated words should not be detected as Roman numerals anymore.
*   _Bugfix_: The Unicode hyphen character (‐) is recognized as a valid word combiner.

