### PR TITLE
Refactor title filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 5.6.0 - unreleased
+*   _Change_: The HTML title handling has been reengineered, and consequently, the
+    `title` variant of the `typo_disable_filtering` hook has been removed.  
+
 ## 5.5.4 - March 11, 2019
 *   _Bugfix_: Automatic language detection now also works for locales without a country code (e.g. `fi`).
 *   _Bugfix_: No PHP notices are shown for missing options anymore.

--- a/includes/wp-typography/components/class-public-interface.php
+++ b/includes/wp-typography/components/class-public-interface.php
@@ -157,8 +157,6 @@ class Public_Interface implements Plugin_Component {
 			'content' => [ $this, 'enable_content_filters' ],
 			// Add filters for headings.
 			'heading' => [ $this, 'enable_heading_filters' ],
-			// Extra care needs to be taken with the <title> tag.
-			'title'   => [ $this, 'enable_title_filters' ],
 		];
 
 		/**
@@ -189,9 +187,10 @@ class Public_Interface implements Plugin_Component {
 			 *
 			 * @since 3.6.0
 			 * @since 5.2.0 WooCommerce support added ($filter_group 'woocommerce').
+			 * @since 5.6.0 Filter group `title` removed.
 			 *
 			 * @param bool   $disable      Whether to disable automatic filtering. Default false.
-			 * @param string $filter_group Which filters to disable. Possible values 'content', 'heading', 'title', 'acf', 'woocommerce'.
+			 * @param string $filter_group Which filters to disable. Possible values 'content', 'heading', 'acf', 'woocommerce'.
 			 */
 			if ( ! \apply_filters( 'typo_disable_filtering', false, $tag ) ) {
 				$enable( $priority );
@@ -214,6 +213,7 @@ class Public_Interface implements Plugin_Component {
 		\add_filter( 'link_name',         [ $this->plugin, 'process' ], $priority );
 		\add_filter( 'the_excerpt',       [ $this->plugin, 'process' ], $priority );
 		\add_filter( 'the_excerpt_embed', [ $this->plugin, 'process' ], $priority );
+		\add_filter( 'wp_dropdown_cats',  [ $this->plugin, 'process' ], $priority );
 
 		// Preserve shortcode handling on WordPress 4.8+.
 		if ( \version_compare( \get_bloginfo( 'version' ), '4.8', '>=' ) ) {
@@ -229,27 +229,8 @@ class Public_Interface implements Plugin_Component {
 	 * @param int $priority Filter priority.
 	 */
 	private function enable_heading_filters( $priority ) {
-		\add_filter( 'the_title',            [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'single_post_title',    [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'single_cat_title',     [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'single_tag_title',     [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'single_month_title',   [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'single_month_title',   [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'nav_menu_attr_title',  [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'nav_menu_description', [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'widget_title',         [ $this->plugin, 'process_title' ], $priority );
-		\add_filter( 'list_cats',            [ $this->plugin, 'process_title' ], $priority );
-	}
-
-	/**
-	 * Enable the title (not heading) filters.
-	 *
-	 * @param int $priority Filter priority.
-	 */
-	private function enable_title_filters( $priority ) {
-		\add_filter( 'wp_title',             [ $this->plugin, 'process_feed' ],        $priority ); // WP < 4.4.
-		\add_filter( 'document_title_parts', [ $this->plugin, 'process_title_parts' ], $priority );
-		\add_filter( 'wp_title_parts',       [ $this->plugin, 'process_title_parts' ], $priority ); // WP < 4.4.
+		\add_filter( 'the_title',    [ $this->plugin, 'process_title' ], $priority );
+		\add_filter( 'widget_title', [ $this->plugin, 'process_title' ], $priority );
 	}
 
 	/**

--- a/tests/components/class-public-interface-test.php
+++ b/tests/components/class-public-interface-test.php
@@ -229,28 +229,16 @@ class Public_Interface_Test extends TestCase {
 			'the_excerpt',
 			'the_excerpt_embed',
 			'widget_text',
+			'wp_dropdown_cats',
 		];
 		$heading_hooks = [
 			'the_title',
-			'single_post_title',
-			'single_cat_title',
-			'single_tag_title',
-			'single_month_title',
-			'nav_menu_attr_title',
-			'nav_menu_description',
 			'widget_title',
-			'list_cats',
-		];
-		$title_hooks   = [
-			'wp_title'             => 'process_feed',
-			'document_title_parts' => 'process_title_parts',
-			'wp_title_parts'       => 'process_title_parts',
 		];
 
 		Filters\expectApplied( 'typo_filter_priority' )->once();
 		Filters\expectApplied( 'typo_disable_filtering' )->once()->with( false, 'content' )->andReturn( $content );
 		Filters\expectApplied( 'typo_disable_filtering' )->once()->with( false, 'heading' )->andReturn( $heading );
-		Filters\expectApplied( 'typo_disable_filtering' )->once()->with( false, 'title' )->andReturn( $title );
 
 		if ( ! $content ) {
 			Functions\expect( 'get_bloginfo' )->once()->with( 'version' )->andReturn( $wp_version );
@@ -275,13 +263,6 @@ class Public_Interface_Test extends TestCase {
 		$expected = ! $heading;
 		foreach ( $heading_hooks as $hook ) {
 			$found = has_filter( $hook, "{$plugin_class}->process_title()" );
-			$this->assertEquals( $expected, $found, "Hook $hook" . ( $expected ? '' : ' not' ) . ' expected, but' . ( $found ? '' : ' not' ) . ' found.' );
-		}
-
-		// Title hooks.
-		$expected = ! $title;
-		foreach ( $title_hooks as $hook => $method ) {
-			$found = has_filter( $hook, "{$plugin_class}->{$method}()" );
 			$this->assertEquals( $expected, $found, "Hook $hook" . ( $expected ? '' : ' not' ) . ' expected, but' . ( $found ? '' : ' not' ) . ' found.' );
 		}
 	}

--- a/tests/settings/class-tools-test.php
+++ b/tests/settings/class-tools-test.php
@@ -26,6 +26,8 @@ namespace WP_Typography\Tests\Settings;
 
 use WP_Typography\Settings\Tools;
 
+use PHP_Typography\U;
+
 use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
@@ -50,17 +52,17 @@ class Tools_Test extends \WP_Typography\Tests\TestCase {
 	public function test_parse_smart_quote_exceptions_string() {
 		$input  = "'tain't,'twere,'twas,'tis,   ,'twill,'til,'bout,'nuff,'round,'cause,'em, ,";
 		$result = [
-			"'tain't" => '’tain’t',
-			"'twere"  => '’twere',
-			"'twas"   => '’twas',
-			"'tis"    => '’tis',
-			"'twill"  => '’twill',
-			"'til"    => '’til',
-			"'bout"   => '’bout',
-			"'nuff"   => '’nuff',
-			"'round"  => '’round',
-			"'cause"  => '’cause',
-			"'em"     => '’em',
+			"'tain't" => U::APOSTROPHE . 'tain' . U::APOSTROPHE . 't',
+			"'twere"  => U::APOSTROPHE . 'twere',
+			"'twas"   => U::APOSTROPHE . 'twas',
+			"'tis"    => U::APOSTROPHE . 'tis',
+			"'twill"  => U::APOSTROPHE . 'twill',
+			"'til"    => U::APOSTROPHE . 'til',
+			"'bout"   => U::APOSTROPHE . 'bout',
+			"'nuff"   => U::APOSTROPHE . 'nuff',
+			"'round"  => U::APOSTROPHE . 'round',
+			"'cause"  => U::APOSTROPHE . 'cause',
+			"'em"     => U::APOSTROPHE . 'em',
 		];
 
 		$this->assertSame( $result, Tools::parse_smart_quote_exceptions_string( $input ) );


### PR DESCRIPTION
Fixes #246.

Changes proposed in this pull request:
- Removed the `title` variant of `typo_disable_filtering`.
- HTML markup in `<title>` is now prevented by not filtering certain hooks that would not expect HTML.