### PR TITLE
Disable CSS hook injection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 5.6.0 - unreleased
 *   _Change_: The HTML title handling has been reengineered, and consequently, the
-    `title` variant of the `typo_disable_filtering` hook has been removed.  
+    `title` variant of the `typo_disable_filtering` hook has been removed.
+*   _Change_: CSS class injection for ampersands, acronyms, and intial quotes is
+    now disabled by default.
 
 ## 5.5.4 - March 11, 2019
 *   _Bugfix_: Automatic language detection now also works for locales without a country code (e.g. `fi`).

--- a/includes/wp-typography/settings/class-plugin-configuration.php
+++ b/includes/wp-typography/settings/class-plugin-configuration.php
@@ -566,7 +566,7 @@ abstract class Plugin_Configuration {
 					'short'         => \__( 'Ampersands', 'wp-typography' ),
 					/* translators: 1: checkbox HTML */
 					'label'         => \__( '%1$s Wrap ampersands [ <code>&amp;</code> ] with <code>&lt;span class="amp"&gt;</code>.', 'wp-typography' ),
-					'default'       => 1,
+					'default'       => 0,
 				],
 				self::STYLE_CAPS                       => [
 					'ui'            => Controls\Checkbox_Input::class,
@@ -574,7 +574,7 @@ abstract class Plugin_Configuration {
 					'short'         => \__( 'Caps', 'wp-typography' ),
 					/* translators: 1: checkbox HTML */
 					'label'         => \__( '%1$s Wrap acronyms (all capitals) with <code>&lt;span class="caps"&gt;</code>.', 'wp-typography' ),
-					'default'       => 1,
+					'default'       => 0,
 				],
 				self::STYLE_NUMBERS                    => [
 					'ui'            => Controls\Checkbox_Input::class,
@@ -600,7 +600,7 @@ abstract class Plugin_Configuration {
 					/* translators: 1: checkbox HTML */
 					'label'         => \__( '%1$s Wrap initial quotes.', 'wp-typography' ),
 					'help_text'     => \__( 'Matches quotemarks at the beginning of blocks of text, not all opening quotemarks. <br />Single quotes [ <code>&lsquo;</code> <code>&#8218;</code> ] are wrapped with <code>&lt;span class="quo"&gt;</code>. <br />Double quotes [ <code>&ldquo;</code> <code>&#8222;</code> ] are wrapped with <code>&lt;span class="dquo"&gt;</code>. <br />Guillemets [ <code>&laquo;</code> <code>&raquo;</code> ] are wrapped with <code>&lt;span class="dquo"&gt;</code>.', 'wp-typography' ),
-					'default'       => 1,
+					'default'       => 0,
 				],
 				self::INITIAL_QUOTE_TAGS               => [
 					'ui'            => Controls\Textarea::class,


### PR DESCRIPTION
Fixes #252.

Changes proposed in this pull request:
- Ampersands, all-caps words, and initial quotes are no longer wrapped in `<span>` by default.
