### PR TITLE
Add GUI for special character remapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
     hair spaces for numeric intervals (i.e. `9-17` becomes `9&ndash;17` instead
     of `9&hairsp;&ndash;&hairsp;17`).
 *   _Feature_: Smart area and volume units (`5m2` is transformed into `5 m²`).
+*   _Feature_: The use of narrow no-break spaces and the true Unicode hyphen can
+    now be enabled via the GUI. Consequently, the filter hook `typo_narrow_no_break_space`
+    has been deprecated.
 *   _Change_: The HTML title handling has been reengineered, and consequently, the
     `title` variant of the `typo_disable_filtering` hook has been removed.
 *   _Change_: CSS class injection for ampersands, acronyms, and intial quotes is

--- a/includes/wp-typography/class-implementation.php
+++ b/includes/wp-typography/class-implementation.php
@@ -529,6 +529,28 @@ class Implementation extends \WP_Typography {
 		$s->set_classes_to_ignore( $config[ Config::IGNORE_CLASSES ] );
 		$s->set_ids_to_ignore( $config[ Config::IGNORE_IDS ] );
 
+		// Remap problematic Unicode characters.
+		$hyphen = ! empty( $config[ Config::REMAP_HYPHEN ] ) ? U::HYPHEN_MINUS : U::HYPHEN;
+		$s->remap_character( U::HYPHEN, $hyphen );
+
+		/**
+		 * Filters whether to use the NARROW NO-BREAK SPACE character (U+202F, &#8239;)
+		 * where appropriate.
+		 *
+		 * Historically, browser and/or font support for this character has been limited,
+		 * so by default it is replaced by the normal (non-narrow) NO-BREAK SPACE (U+00A0, &nbsp;).
+		 *
+		 * @since 5.1.0
+		 *
+		 * @deprecated 5.6.0 Use the GUI setting instead or filter the option
+		 *                   'remap_narrow_no_break_space' (with inverse meaning
+		 *                   of the boolean value).
+		 *
+		 * @param bool $enable Default true if the UI is set to not remap the character.
+		 */
+		$narrow_no_break_space = \apply_filters( 'typo_narrow_no_break_space', empty( $config[ Config::REMAP_NARROW_NO_BREAK_SPACE ] ) ) ? U::NO_BREAK_NARROW_SPACE : U::NO_BREAK_SPACE;
+		$s->remap_character( U::NO_BREAK_NARROW_SPACE, $narrow_no_break_space );
+
 		if ( $config[ Config::SMART_CHARACTERS ] ) {
 			$s->set_smart_dashes( $config[ Config::SMART_DASHES ] );
 			$s->set_smart_ellipses( $config[ Config::SMART_ELLIPSES ] );
@@ -573,19 +595,6 @@ class Implementation extends \WP_Typography {
 		$s->set_dewidow( $config[ Config::PREVENT_WIDOWS ] );
 		$s->set_max_dewidow_length( $config[ Config::WIDOW_MIN_LENGTH ] );
 		$s->set_max_dewidow_pull( $config[ Config::WIDOW_MAX_PULL ] );
-
-		/**
-		 * Filters whether to use the NARROW NO-BREAK SPACE character (U+202F, &#8239;)
-		 * where appropriate.
-		 *
-		 * Historically, browser and/or font support for this character has been limited,
-		 * so by default it is replaced by the normal (non-narrow) NO-BREAK SPACE (U+00A0, &nbsp;).
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param bool $enable Default false.
-		 */
-		$s->set_true_no_break_narrow_space( apply_filters( 'typo_narrow_no_break_space', false ) );
 
 		// Line wrapping.
 		$s->set_wrap_hard_hyphens( $config[ Config::WRAP_HYPHENS ] );

--- a/includes/wp-typography/settings/class-plugin-configuration.php
+++ b/includes/wp-typography/settings/class-plugin-configuration.php
@@ -48,6 +48,8 @@ abstract class Plugin_Configuration {
 	const IGNORE_TAGS                      = 'ignore_tags';
 	const IGNORE_CLASSES                   = 'ignore_classes';
 	const IGNORE_IDS                       = 'ignore_ids';
+	const REMAP_NARROW_NO_BREAK_SPACE      = 'remap_narrow_no_break_space';
+	const REMAP_HYPHEN                     = 'remap_hyphen';
 	const ENABLE_MULTILINGUAL_SUPPORT      = 'enable_multilingual_support';
 	const SMART_CHARACTERS                 = 'smart_characters';
 	const SMART_DASHES                     = 'smart_dashes';
@@ -156,6 +158,24 @@ abstract class Plugin_Configuration {
 					'label'         => \__( '%1$s Enable support for using multiple languages on the same site.', 'wp-typography' ),
 					'help_text'     => \__( 'Enable if you are using multilingual plugin like WPML or Polylang and want automatic hyphenation language, dash and quote style adjustments.', 'wp-typography' ),
 					'default'       => 0,
+				],
+				self::REMAP_NARROW_NO_BREAK_SPACE      => [
+					'ui'            => Controls\Checkbox_Input::class,
+					'tab_id'        => Tabs::GENERAL_SCOPE,
+					'section'       => Sections::SPECIAL_CHARACTERS,
+					'short'         => \__( 'Narrow no-break space', 'wp-typography' ),
+					/* translators: 1: checkbox HTML */
+					'label'         => \__( '%1$s Replace narrow no-break spaces [ <code>X&#8239;Y</code> ] with regular no-break spaces [ <code>X&nbsp;Y</code> ].', 'wp-typography' ),
+					'default'       => 1,
+				],
+				self::REMAP_HYPHEN                     => [
+					'ui'            => Controls\Checkbox_Input::class,
+					'tab_id'        => Tabs::GENERAL_SCOPE,
+					'section'       => Sections::SPECIAL_CHARACTERS,
+					'short'         => \__( 'Hyphen', 'wp-typography' ),
+					/* translators: 1: checkbox HTML */
+					'label'         => \__( '%1$s Replace Unicode hyphens [ <code>&#8208;</code> ] with the ASCII hyphen-minus [ <code>-</code> ].', 'wp-typography' ),
+					'default'       => 1,
 				],
 				self::ENABLE_HYPHENATION               => [
 					'ui'            => Controls\Checkbox_Input::class,

--- a/includes/wp-typography/ui/class-sections.php
+++ b/includes/wp-typography/ui/class-sections.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2019 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -36,8 +36,9 @@ namespace WP_Typography\UI;
 abstract class Sections {
 
 	// Section ID constants.
-	const MATH_REPLACEMENTS = 'math-replacements';
-	const LINE_WRAPPING     = 'line-wrapping';
+	const MATH_REPLACEMENTS  = 'math-replacements';
+	const SPECIAL_CHARACTERS = 'special-characters';
+	const LINE_WRAPPING      = 'line-wrapping';
 
 	/**
 	 * The defaults array.
@@ -62,12 +63,17 @@ abstract class Sections {
 	public static function get_sections() {
 		if ( empty( self::$sections ) ) {
 			self::$sections = [ // @codeCoverageIgnore
-				self::MATH_REPLACEMENTS => [
+				self::SPECIAL_CHARACTERS => [
+					'heading'     => \__( 'Special Characters', 'wp-typography' ),
+					'description' => \__( 'Some Unicode characters still cause issues with certain browsers, and some fonts may be missing the correct glyphs.', 'wp-typography' ),
+					'tab_id'      => Tabs::GENERAL_SCOPE,
+				],
+				self::MATH_REPLACEMENTS  => [
 					'heading'     => \__( 'Math & Numbers', 'wp-typography' ),
 					'description' => \__( 'Not all number formattings are appropriate for all languages.', 'wp-typography' ),
 					'tab_id'      => Tabs::CHARACTER_REPLACEMENT,
 				],
-				self::LINE_WRAPPING     => [
+				self::LINE_WRAPPING      => [
 					'heading'     => \__( 'Line Wrapping', 'wp-typography' ),
 					'description' => \__( 'Sometimes you want to enable certain long words to wrap to a new line, while at other times you want to prevent wrapping.', 'wp-typography' ),
 					'tab_id'      => Tabs::SPACE_CONTROL,

--- a/tests/class-wp-typography-implementation-test.php
+++ b/tests/class-wp-typography-implementation-test.php
@@ -202,12 +202,15 @@ class WP_Typography_Implementation_Test extends TestCase {
 	 * @uses ::init_settings_from_options
 	 */
 	public function test_get_settings() {
+		$remap_narrow_no_break_space = false;
 
 		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn(
 			[
 				Config::IGNORE_TAGS                    => [ 'script' ],
 				Config::IGNORE_CLASSES                 => [ 'noTypo' ],
 				Config::IGNORE_IDS                     => [],
+				Config::REMAP_NARROW_NO_BREAK_SPACE    => $remap_narrow_no_break_space,
+				Config::REMAP_HYPHEN                   => false,
 				Config::SMART_CHARACTERS               => true,
 				Config::SMART_DASHES                   => false,
 				Config::SMART_DASHES_STYLE             => 'international',
@@ -266,7 +269,7 @@ class WP_Typography_Implementation_Test extends TestCase {
 		$this->wp_typo->shouldReceive( 'prepare_smart_quotes_exceptions' )->once()->with( m::type( 'array' ) )->andReturn( [] );
 
 		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
-		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( ! $remap_narrow_no_break_space )->once();
 		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
 
 		$s = $this->wp_typo->get_settings();
@@ -283,12 +286,15 @@ class WP_Typography_Implementation_Test extends TestCase {
 	 * @uses ::init_settings_from_options
 	 */
 	public function test_get_settings_hyphenation_off() {
+		$remap_narrow_no_break_space = false;
 
 		$this->wp_typo->shouldReceive( 'get_config' )->once()->andReturn(
 			[
 				Config::IGNORE_TAGS                    => [ 'script' ],
 				Config::IGNORE_CLASSES                 => [ 'noTypo' ],
 				Config::IGNORE_IDS                     => [],
+				Config::REMAP_NARROW_NO_BREAK_SPACE    => $remap_narrow_no_break_space,
+				Config::REMAP_HYPHEN                   => false,
 				Config::SMART_CHARACTERS               => false,
 				Config::SMART_DASHES                   => false,
 				Config::SMART_DASHES_STYLE             => 'international',
@@ -344,7 +350,7 @@ class WP_Typography_Implementation_Test extends TestCase {
 		$this->transients->shouldReceive( 'cache_object' )->once();
 
 		Functions\expect( 'wp_json_encode' )->once()->andReturn( '{ json: "value" }' );
-		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( false )->once();
+		Filters\expectApplied( 'typo_narrow_no_break_space' )->with( ! $remap_narrow_no_break_space )->once();
 		Filters\expectApplied( 'typo_ignore_parser_errors' )->with( false )->once();
 
 		$s = $this->wp_typo->get_settings();


### PR DESCRIPTION
Fixes #253.

Changes proposed in this pull request:
- Adds character remapping settings to the General Scope tab.
- Deprecates the specialized `typo_narrow_no_break_space` filter hook.
- Updates the unit tests.