### PR TITLE
Scope third-party dependencies 

### DIFF
--- a/.scoper.inc.php
+++ b/.scoper.inc.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+const WP_TYPOGRAPHY_EXCLUDED_FILES      = '.*\\.dist|Makefile|composer\\.json|composer\\.lock|phpcs\\.xml|phpunit.xml|phpbench\\.json|.*\\.md|.*\\.txt';
+const WP_TYPOGRAPHY_EXCLUDED_DIRS       = [
+    'bin',
+    'doc',
+    'test',
+    'test_old',
+    'tests',
+    'Tests',
+    'vendor-bin',
+    // Partial templates will be copied by Grunt.
+    'partials'
+];
+// Global WordPress functions we use.
+const WP_TYPOGRAPHY_WORDPRESS_FUNCTIONS = [
+    // Transients.
+    'get_transient',
+    'set_transient',
+    'delete_transient',
+    'get_site_transient',
+    'set_site_transient',
+    'delete_site_transient',
+
+    // Options.
+    'get_option',
+    'update_option',
+    'delete_option',
+    'get_network_option',
+    'update_network_option',
+    'delete_network_option',
+
+    // Object caching.
+    'wp_cache_get',
+    'wp_cache_set',
+    'wp_cache_delete',
+    'wp_using_ext_object_cache',
+
+    // Multisite.
+    'get_current_network_id',
+
+    // Escaping and sanitization.
+    'esc_attr',
+    'esc_html',
+    'esc_textarea',
+    'sanitize_text_field',
+    'wp_kses',
+    'wp_kses_allowed_html',
+
+    // Settings API.
+    'add_settings_field',
+
+    // Markup.
+    'checked',
+    'selected',
+
+    // Utility functions.
+    'wp_list_pluck',
+    'wp_parse_args',
+];
+
+return [
+    // The prefix configuration. If a non null value will be used, a random prefix will be generated.
+    'prefix' => 'WP_Typography\Vendor',
+
+    // By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
+    // directory. You can however define which files should be scoped by defining a collection of Finders in the
+    // following configuration key.
+    //
+    // For more see: https://github.com/humbug/php-scoper#finders-and-paths
+    'finders' => [
+        // The DI container needs only one file.
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName( '/' . WP_TYPOGRAPHY_EXCLUDED_FILES . '/' )
+            ->exclude( [
+                'Extra',
+                'Loader',
+                'tests',
+            ] )
+            ->in('vendor/level-2'),
+        // Our own vendor modules.
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName( '/' . WP_TYPOGRAPHY_EXCLUDED_FILES . '/' )
+            ->exclude( WP_TYPOGRAPHY_EXCLUDED_DIRS )
+            ->in('vendor/mundschenk-at'),
+        // The HTML parser.
+        Finder::create()
+            ->files()
+            ->ignoreVCS(true)
+            ->notName( '/' . WP_TYPOGRAPHY_EXCLUDED_FILES . '|example\\.php|sami\\.php/' )
+            ->exclude( WP_TYPOGRAPHY_EXCLUDED_DIRS )
+            ->in('vendor/masterminds'),
+        Finder::create()->append([
+            'composer.json',
+            'vendor/composer/installed.json',
+        ]),
+    ],
+
+    // Whitelists a list of files. Unlike the other whitelist related features, this one is about completely leaving
+    // a file untouched.
+    // Paths are relative to the configuration file unless if they are already absolute
+    'files-whitelist' => [
+        'vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php',
+    ],
+
+    // When scoping PHP files, there will be scenarios where some of the code being scoped indirectly references the
+    // original namespace. These will include, for example, strings or string manipulations. PHP-Scoper has limited
+    // support for prefixing such strings. To circumvent that, you can define patchers to manipulate the file to your
+    // heart contents.
+    //
+    // For more see: https://github.com/humbug/php-scoper#patchers
+    'patchers' => [
+        function (string $file_path, string $prefix, string $contents): string {
+            // Quote prefix.
+            $prefix = \preg_quote( $prefix, '#' );
+
+            if (
+                // Skip partials and dummy files.
+                \preg_match( '#.*/partials/\w+.*\.php$#', $file_path ) ||
+                \preg_match( '#.*/includes/_language_names\.php$#', $file_path )
+            ) {
+                $contents = \preg_replace( "#\b{$prefix}\\\\([\w_]+\()#", '$1', $contents );
+            } elseif (
+                // Only for other PHP files.
+                \preg_match( '#\w+/\w+.*\.php#', $file_path )
+            ) {
+                // Un-preix WordPress functions.
+                $functions = \join( '|', WP_TYPOGRAPHY_WORDPRESS_FUNCTIONS );
+                $contents  = \preg_replace( "/\b{$prefix}\\\\({$functions}\()/", '$1', $contents );
+            }
+
+            return $contents;
+        },
+    ],
+
+    // PHP-Scoper's goal is to make sure that all code for a project lies in a distinct PHP namespace. However, you
+    // may want to share a common API between the bundled code of your PHAR and the consumer code. For example if
+    // you have a PHPUnit PHAR with isolated code, you still want the PHAR to be able to understand the
+    // PHPUnit\Framework\TestCase class.
+    //
+    // A way to achieve this is by specifying a list of classes to not prefix with the following configuration key. Note
+    // that this does not work with functions or constants neither with classes belonging to the global namespace.
+    //
+    // Fore more see https://github.com/humbug/php-scoper#whitelist
+    'whitelist' => [
+        'PHP_Typography\*',
+    ],
+
+    // If `true` then the user defined constants belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-constants' => true,
+
+    // If `true` then the user defined classes belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-classes' => true,
+
+    // If `true` then the user defined functions belonging to the global namespace will not be prefixed.
+    //
+    // For more see https://github.com/humbug/php-scoper#constants--constants--functions-from-the-global-namespace
+    'whitelist-global-functions' => true,
+];

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ matrix:
 # Failures in this section will result in build status 'errored'.
 before_install:
     - if [[ "$SCOPE" == "tests" || "$SCOPE" == "coverage" ]]; then
-            composer install --no-interaction --dev;
+            composer remove humbug/php-scoper --dev --no-interaction;
+            composer install --no-interaction;
             phpenv rehash;
       fi
     - if [[ "$SCOPE" == "coverage" ]]; then composer require php-coveralls/php-coveralls --dev; fi
@@ -64,9 +65,8 @@ script:
     # Search for PHP syntax errors.
     - if [[ "$SCOPE" == "php52" ]]; then
             find -L . -name 'wp-typography.php' -print0 | xargs -0 -n 1 -P 4 php -l;
-            find -L . -name 'class-wp-typography-requirements.php' -print0 | xargs -0 -n 1 -P 4 php -l;
       else
-            find -L . -not \( -path ./tests -prune \) -not \( -path ./vendor -prune \) -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l;
+            find -L . -not \( -path ./tests -prune \) -not \( -path ./vendor -prune \) -name '*.php'  -not \( -name .scoper.inc.php -prune \) -print0 | xargs -0 -n 1 -P 4 php -l;
       fi
     # WordPress Coding Standards.
     - if [[ "$PHPCS" == "1" ]]; then composer phpcs; fi

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,19 +57,8 @@ module.exports = function(grunt) {
                         'includes/**',
                         'admin/**',
                         '!**/scss/**',
-                        'composer.*',
-                        'vendor/composer/**',
-                        'vendor/level-2/dice/Dice.php',
-                        'vendor/masterminds/html5/src/**/*.php',
-                        'vendor/mundschenk-at/check-wp-requirements/*.php',
-                        'vendor/mundschenk-at/check-wp-requirements/partials/*.php',
-                        'vendor/mundschenk-at/wp-settings-ui/src/**/*.php',
-                        'vendor/mundschenk-at/wp-settings-ui/partials/**/*.php',
-                        'vendor/mundschenk-at/wp-data-storage/src/**/*.php',
-                        'vendor/mundschenk-at/php-typography/src/**',
-                        '!vendor/mundschenk-at/php-typography/src/bin/**',
                         'js/**',
-                        '!vendor/**/tests/**'
+                        'vendor/**/partials/**',
                     ],
                     dest: 'build/'
                 }],
@@ -92,7 +81,7 @@ module.exports = function(grunt) {
 
         clean: {
             build: ["build/*"],
-            autoloader: [ "build/tests", "build/composer.*", "build/vendor/composer/*.json", "build/vendor/mundschenk-at/composer-for-wordpress/**" ]
+            autoloader: [ "build/composer.*", "build/vendor/composer/*.json", "build/vendor/scoper-autoload.php", "build/vendor/mundschenk-at/composer-for-wordpress/**" ]
         },
 
         "string-replace": {
@@ -292,6 +281,37 @@ module.exports = function(grunt) {
                 }
             }
         },
+
+        replace: {
+            fix_dice_namespace: {
+                options: {
+                    patterns: [ {
+                        match: /use Dice\\Dice;/g,
+                        replacement: 'use WP_Typography\\Vendor\\Dice\\Dice;'
+                    } ],
+                },
+                files: [ {
+                    expand: true,
+                    flatten: false,
+                    src: ['build/includes/class-wp-typography-factory.php'],
+                    dest: '',
+                } ]
+            },
+            fix_mundschenk_namespace: {
+                options: {
+                    patterns: [ {
+                        match: /(\b\\?)(Mundschenk\\[\w_]+)/g,
+                        replacement: '$1WP_Typography\\Vendor\\$2'
+                    } ],
+                },
+                files: [ {
+                    expand: true,
+                    flatten: false,
+                    src: ['build/includes/**/*.php'],
+                    dest: '',
+                } ]
+            }
+        },
     });
 
     // load all standard tasks
@@ -332,13 +352,14 @@ module.exports = function(grunt) {
 
     grunt.registerTask('build', [
         'clean:build',
+        'composer:dev:scope-dependencies',
         'regex_extract:language_names',
         'exec:update_iana',
         'copy:main',
         'copy:meta',
-        'mkdir:build_tests',
+        'replace:fix_dice_namespace',
+        'replace:fix_mundschenk_namespace',
         'composer:build:build-wordpress',
-        'composer:build:dump-autoload:classmap-authoritative:no-dev',
         'clean:autoloader',
         'string-replace:autoloader',
         'newer:delegate:sass:dist',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,7 @@
 'use strict';
+
+const sass = require('sass');
+
 module.exports = function(grunt) {
 
     // Initialize configuration.
@@ -146,6 +149,9 @@ module.exports = function(grunt) {
         },
 
         sass: {
+            options: {
+                implementation: sass,
+            },
             dist: {
                 options: {
                     outputStyle: 'compressed',
@@ -196,9 +202,8 @@ module.exports = function(grunt) {
             options: {
                 map: true, // inline sourcemaps.
                 processors: [
-                    require('autoprefixer')({
-                        browsers: ['>1%', 'last 2 versions', 'IE 9', 'IE 10']
-                    }) // add vendor prefixes
+                    // add vendor prefixes
+                    require('autoprefixer')()
                 ]
             },
             dev: {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "phpunit/phpunit": "5.*||6.*||7.*",
         "mikey179/vfsstream": "~1",
         "brain/monkey": "^2.2",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "humbug/php-scoper": "^0.12.4"
     },
 
     "minimum-stability": "dev",
@@ -81,9 +82,13 @@
           "#phpstan analyse --configuration=.phpstan.neon --level=6 --ansi tests/",
           "@composer remove phpstan/phpstan --dev --quiet"
       ],
+      "scope-dependencies": [
+          "@php vendor/bin/php-scoper add-prefix --config=.scoper.inc.php --force --quiet"
+      ],
       "build-wordpress": [
           "@composer require mundschenk-at/composer-for-wordpress=dev-master --no-update",
-          "@composer update --no-dev"
+          "@composer update --no-dev",
+          "@composer dump-autoload --classmap-authoritative --no-dev"
       ],
       "clean-wordpress": [
           "@composer remove mundschenk-at/composer-for-wordpress"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-newer": "^1.3",
     "grunt-postcss": "^0.9",
     "grunt-regex-extract": "git://github.com/mpau23/grunt-regex-extract.git",
+    "grunt-replace": "^1.0.1",
     "grunt-sass": "^3.0.2",
     "grunt-shell": "^3",
     "grunt-string-replace": "^1.3",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,16 @@
     "grunt-shell": "^3",
     "grunt-string-replace": "^1.3",
     "grunt-wp-deploy": "^2.0.0",
-    "load-grunt-tasks": "^5.0.0"
+    "load-grunt-tasks": "^5.0.0",
+    "sass": "^1.20.3"
   },
+  "browserslist": [
+    "last 2 version",
+    "> 1%",
+    "IE 9",
+    "IE 10",
+    "IE 11"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/mundschenk-at/wp-typography.git"


### PR DESCRIPTION
Changes proposed in this pull request:
- All dependencies except the core `PHP_Typography` package get moved under `WP_Typography\Vendor`.
- The build system has been updated.
- Browser-prefixing uses the new-style configuration.
