### PR TITLE
Scope vendor directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "config": {
         "classmap-authoritative": false,
         "classloader-suffix": "WPTypography",
-        "autoloader-suffix": "WPTypography"
+        "autoloader-suffix": "WPTypography",
+        "vendor-dir": "vendor"
     },
 
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-newer": "^1.3",
     "grunt-postcss": "^0.9",
     "grunt-regex-extract": "git://github.com/mpau23/grunt-regex-extract.git",
+    "grunt-rename-util": "^1.0.0",
     "grunt-replace": "^1.0.1",
     "grunt-sass": "^3.0.2",
     "grunt-shell": "^3",


### PR DESCRIPTION
Changes proposed in this pull request:
- Moves `vendor/`directory to `vendor-scoped/` to make sure GlotPress picks up the strings.
- Updates Grunt dependencies.
