### PR TITLE
Update integration tooling to use PHP 7.3 and PHP 7.4

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -29,7 +29,7 @@ build:
         memcached: false
         neo4j: false
         php:
-            version: 7.2
+            version: 7.4
     nodes:
         analysis:
             project_setup:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ matrix:
           env:  SCOPE=tests
         # aliased to a recent 7.2 version
         - php:  '7.2'
+          env:  SCOPE=tests
+        # aliased to a recent 7.3 version
+        - php:  '7.3'
+          env:  SCOPE=tests
+        # aliased to a recent 7.4 version
+        - php:  '7.4'
           env:  SCOPE=coverage
 
 # Use this to prepare the system to install prerequisites or dependencies.


### PR DESCRIPTION
Changes proposed in this pull request:
- Scrutinizer-CI analysis runs on PHP 7.4.
- Travis tests run on PHP 7.3 and PHP 7.4.
