### PR TITLE
Check for DOM extension

### DIFF
--- a/includes/class-wp-typography-factory.php
+++ b/includes/class-wp-typography-factory.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -94,7 +94,7 @@ abstract class WP_Typography_Factory {
 						'instance' => \WP_Typography\Implementation::class,
 					],
 				],
-				WP_Typography::class    => [
+				\WP_Typography::class   => [
 					'constructParams' => [ \get_plugin_data( \WP_TYPOGRAPHY_PLUGIN_FILE, false, false )['Version'] ],
 				],
 			];

--- a/includes/class-wp-typography-requirements.php
+++ b/includes/class-wp-typography-requirements.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of wp-Typography.
+ *
+ * Copyright 2020 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/wp-typography
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+// We can't rely on autoloading for the requirements check.
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php'; // @codeCoverageIgnore
+
+/**
+ * A custom requirements class to check for additional PHP packages and other
+ * prerequisites.
+ *
+ * @since 5.7.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class WP_Typography_Requirements extends Mundschenk_WP_Requirements {
+
+	/**
+	 * Creates a new requirements instance.
+	 */
+	public function __construct() {
+		$requirements = array(
+			'php'              => '5.6.0',
+			'multibyte'        => true,
+			'utf-8'            => true,
+			'dom'              => true,
+		);
+
+		parent::__construct( 'wp-Typography', WP_TYPOGRAPHY_PLUGIN_FILE, 'wp-typography', $requirements );
+	}
+
+	/**
+	 * Retrieves an array of requirement specifications.
+	 *
+	 * @return array {
+	 *         An array of requirements checks.
+	 *
+	 *   @type string   $enable_key An index in the $install_requirements array to switch the check on and off.
+	 *   @type callable $check      A function returning true if the check was successful, false otherwise.
+	 *   @type callable $notice     A function displaying an appropriate error notice.
+	 * }
+	 */
+	protected function get_requirements() {
+		$requirements   = parent::get_requirements();
+		$requirements[] = array(
+			'enable_key' => 'dom',
+			'check'      => array( $this, 'check_dom_support' ),
+			'notice'     => array( $this, 'admin_notices_dom_disabled' ),
+		);
+
+		return $requirements;
+	}
+
+	/**
+	 * Checks for availability of the DOM extension.
+	 *
+	 * @return bool
+	 */
+	protected function check_dom_support() {
+		return class_exists( 'DOMDocument' );
+	}
+
+	/**
+	 * Prints 'DOM extension missing' admin notice
+	 */
+	public function admin_notices_dom_disabled() {
+		$this->display_error_notice(
+			/* translators: 1: plugin name 2: GD documentation URL */
+			__( 'The activated plugin %1$s requires the DOM PHP extension to be enabled on your server. Please deactivate this plugin, or <a href="%2$s">enable the extension</a>.', 'wp-typography' ),
+			'<strong>wp-Typography</strong>',
+			/* translators: URL with GD PHP extension installation instructions */
+			__( 'https://www.php.net/manual/en/dom.setup.php', 'wp-typography' )
+		);
+	}
+}

--- a/includes/wp-typography/components/class-admin-interface.php
+++ b/includes/wp-typography/components/class-admin-interface.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2014-2019 Peter Putzer.
+ *  Copyright 2014-2020 Peter Putzer.
  *  Copyright 2012-2013 Marie Hogebrandt.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
@@ -454,7 +454,7 @@ class Admin_Interface implements Plugin_Component {
 		}
 
 		// Load the settings page HTML.
-		require \dirname( \WP_TYPOGRAPHY_PLUGIN_FILE ) . '/admin/partials/settings/section.php';
+		require \WP_TYPOGRAPHY_PLUGIN_PATH . '/admin/partials/settings/section.php';
 	}
 
 	/**
@@ -488,7 +488,7 @@ class Admin_Interface implements Plugin_Component {
 		$this->admin_form_controls[ Config::DIACRITIC_LANGUAGES ]->set_option_values( $this->plugin->get_diacritic_languages() );
 
 		// Load the settings page HTML.
-		require \dirname( \WP_TYPOGRAPHY_PLUGIN_FILE ) . '/admin/partials/settings/settings-page.php';
+		require \WP_TYPOGRAPHY_PLUGIN_PATH . '/admin/partials/settings/settings-page.php';
 	}
 
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -30,4 +30,7 @@ require_once \dirname( __DIR__ ) . '/vendor/autoload.php';
 // wp-Typography constants.
 if ( ! \defined( 'WP_TYPOGRAPHY_PLUGIN_FILE' ) ) {
 	\define( 'WP_TYPOGRAPHY_PLUGIN_FILE', 'plugin/file' );
+}
+if ( ! \defined( 'WP_TYPOGRAPHY_PLUGIN_PATH' ) ) {
+	\define( 'WP_TYPOGRAPHY_PLUGIN_PATH', 'plugin' );
 }

--- a/tests/class-wp-typography-requirements-test.php
+++ b/tests/class-wp-typography-requirements-test.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * This file is part of wp-Typography.
+ *
+ * Copyright 2020 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  ***
+ *
+ * @package mundschenk-at/wp-typography/tests
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Tests;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+use Mockery as m;
+
+/**
+ * WP_Typography_Requirements unit test.
+ *
+ * @coversDefaultClass \WP_Typography_Requirements
+ * @usesDefaultClass \WP_Typography_Requirements
+ */
+class WP_Typography_Requirements_Test extends Testcase {
+
+	/**
+	 * The system-under-test.
+	 *
+	 * @var \WP_Typography_Requirements
+	 */
+	private $sut;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @since 2.3.3 Renamed to `set_up`.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->sut = m::mock( \WP_Typography_Requirements::class )->makePartial()->shouldAllowMockingProtectedMethods();
+	}
+
+	/**
+	 * Test ::__construct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+
+		Functions\expect( 'wp_parse_args' )->andReturnUsing(
+			function( $args, $defaults ) {
+				return \array_merge( $defaults, $args );
+			}
+		);
+		$req = m::mock( \WP_Typography_Requirements::class )->makePartial();
+		$req->__construct( 'some_file' );
+
+		$this->assertSame( 'wp-Typography', $this->get_value( $req, 'plugin_name' ) );
+		$this->assertSame( 'wp-typography', $this->get_value( $req, 'textdomain' ) );
+		$this->assertSame(
+			[
+				'php'              => '5.6.0',
+				'multibyte'        => true,
+				'utf-8'            => true,
+				'dom'              => true,
+			],
+			$this->get_value( $req, 'install_requirements' )
+		);
+	}
+
+	/**
+	 * Test ::get_requirements.
+	 *
+	 * @covers ::get_requirements
+	 */
+	public function test_get_requirements() {
+		$req_keys = \array_column( $this->sut->get_requirements(), 'enable_key' );
+
+		$this->assertContains( 'dom', $req_keys );
+	}
+
+	/**
+	 * Test ::check_dom_support (successful).
+	 *
+	 * @covers ::check_dom_support
+	 */
+	public function test_check_dom_support() {
+		// Mocking tests for PHP extensions is difficult.
+		$dom = class_exists( 'DOMDocument' );
+
+		$this->assertSame( $dom, $this->sut->check_dom_support() );
+	}
+
+	/**
+	 * Test ::admin_notices_dom_disabled.
+	 *
+	 * @covers ::admin_notices_dom_disabled
+	 */
+	public function test_admin_notices_dom_disabled() {
+		Functions\when( '__' )->returnArg();
+
+		$this->sut->shouldReceive( 'display_error_notice' )->once()->with( m::type( 'string' ), m::type( 'string' ), m::type( 'string' ) );
+
+		$this->assertNull( $this->sut->admin_notices_dom_disabled() );
+	}
+}

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -52,6 +52,9 @@ if ( ! defined( 'ABSPATH' ) || ! defined( 'WPINC' ) ) {
 if ( ! defined( 'WP_TYPOGRAPHY_PLUGIN_FILE' ) ) {
 	define( 'WP_TYPOGRAPHY_PLUGIN_FILE', __FILE__ );
 }
+if ( ! defined( 'WP_TYPOGRAPHY_PLUGIN_PATH' ) ) {
+	define( 'WP_TYPOGRAPHY_PLUGIN_PATH', dirname( __FILE__ ) );
+}
 
 // Load requirements class in a PHP 5.2 compatible manner.
 require_once dirname( __FILE__ ) . '/includes/class-wp-typography-requirements.php';

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2014-2019 Peter Putzer.
+ *  Copyright 2014-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -54,7 +54,7 @@ if ( ! defined( 'WP_TYPOGRAPHY_PLUGIN_FILE' ) ) {
 }
 
 // Load requirements class in a PHP 5.2 compatible manner.
-require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/class-mundschenk-wp-requirements.php';
+require_once dirname( __FILE__ ) . '/includes/class-wp-typography-requirements.php';
 
 /**
  * Load the plugin after checking for the necessary PHP version.
@@ -62,15 +62,8 @@ require_once dirname( __FILE__ ) . '/vendor/mundschenk-at/check-wp-requirements/
  * It's necessary to do this here because main class relies on namespaces.
  */
 function wp_typography_run() {
-	// Define our requirements.
-	$reqs = array(
-		'php'       => '5.6.0',
-		'multibyte' => true,
-		'utf-8'     => true,
-	);
-
 	// Validate the requirements.
-	$requirements = new Mundschenk_WP_Requirements( 'wp-Typography', WP_TYPOGRAPHY_PLUGIN_FILE, 'wp-typography', $reqs );
+	$requirements = new WP_Typography_Requirements();
 	if ( $requirements->check() ) {
 		// Autoload the rest of our classes.
 		require_once __DIR__ . '/vendor/autoload.php'; // phpcs:ignore PHPCompatibility.Keywords.NewKeywords.t_dirFound

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -29,7 +29,7 @@
  *  Description: Improve your web typography with: hyphenation, space control, intelligent character replacement, and CSS hooks.
  *  Author: Peter Putzer
  *  Author URI: https://code.mundschenk.at
- *  Version: 5.6.1
+ *  Version: 5.7.0-alpha.1
  *  License: GNU General Public License v2 or later
  *  License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *  Text Domain: wp-typography


### PR DESCRIPTION
Fixes #266.

Changes proposed in this pull request:
- Adds a check that the DOM extension is activated.
- Introduces `WP_TYPOGRAPHY_PLUGIN_PATH` constant.
- Bumps version to `5.7.0-alpha.1`.