### PR TITLE
Basic PHP 8.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
 
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0.0",
         "mundschenk-at/php-typography": "^6.6.0",
         "level-2/dice": "^2.0.3",
         "mundschenk-at/check-wp-requirements": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,15 @@
 
     "repositories": [
         {
+            "type": "git",
+            "url": "https://github.com/mundschenk-at/Dice/"
         }
     ],
 
     "require": {
         "php": ">=7.0.0",
         "mundschenk-at/php-typography": "^6.6.0",
-        "level-2/dice": "^2.0.3",
+        "level-2/dice": "dev-php8 as 4.0.2",
         "mundschenk-at/check-wp-requirements": "^1.0",
         "mundschenk-at/wp-data-storage": "^1.0",
         "mundschenk-at/wp-settings-ui": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,10 @@
         "phpcompatibility/php-compatibility": "^9.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "phpunit/phpunit": "5.*||6.*||7.*||8.*||9.*",
-        "phpunit/php-code-coverage": "<9.1.8",
         "mikey179/vfsstream": "~1",
         "brain/monkey": "^2.2",
         "roave/security-advisories": "dev-master",
-        "humbug/php-scoper": "^0.13",
+        "humbug/php-scoper": "^0.15",
         "mundschenk-at/phpunit-cross-version": "dev-master"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
           "phpunit --testsuite wp-Typography"
       ],
       "coverage": [
-          "phpunit --testsuite wp-Typography --coverage-html tests/coverage"
+          "XDEBUG_MODE=coverage phpunit --testsuite wp-Typography --coverage-html tests/coverage"
       ],
       "check": [
           "@phpcs",

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
 
     "repositories": [
         {
-            "type": "vcs",
-            "url": "https://github.com/mundschenk-at/composer-for-wordpress.git",
-            "no-api": true
         }
     ],
 
@@ -32,8 +29,7 @@
         "level-2/dice": "^2.0.3",
         "mundschenk-at/check-wp-requirements": "^1.0",
         "mundschenk-at/wp-data-storage": "^1.0",
-        "mundschenk-at/wp-settings-ui": "dev-master",
-        "mundschenk-at/composer-for-wordpress": "dev-master"
+        "mundschenk-at/wp-settings-ui": "dev-master"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
@@ -67,7 +63,7 @@
         "platform-check": false,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "mundschenk-at/composer-for-wordpress": true
+            "danngoodman/composer-for-wordpress": true
         }
     },
 
@@ -95,7 +91,7 @@
           "@php vendor/bin/php-scoper add-prefix --config=.scoper.inc.php --force --quiet"
       ],
       "build-wordpress": [
-          "@composer require mundschenk-at/composer-for-wordpress=dev-master --no-update",
+          "@composer require dangoodman/composer-for-wordpress --no-update",
           "@composer update --no-dev",
           "@composer dump-autoload --classmap-authoritative --no-dev"
       ],

--- a/includes/class-wp-typography-factory.php
+++ b/includes/class-wp-typography-factory.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of wp-Typography.
  *
- *  Copyright 2017-2020 Peter Putzer.
+ *  Copyright 2017-2021 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -38,6 +38,8 @@ use WP_Typography\Integration\Container as Integrations;
 use WP_Typography\Settings\Basic_Locale_Settings;
 use WP_Typography\Settings\Locale_Settings;
 
+use WP_Typography\Exceptions\Object_Factory_Exception;
+
 use PHP_Typography\Settings\Dash_Style;
 use PHP_Typography\Settings\Quote_Style;
 
@@ -65,26 +67,34 @@ class WP_Typography_Factory extends Dice {
 	 * Creates a new instance.
 	 *
 	 * @since 5.7.0
+	 * @since 5.8.0 Constructor is now final.
 	 */
-	protected function __construct() {
-		// Add rules.
-		foreach ( $this->get_rules() as $classname => $rule ) {
-			$this->addRule( $classname, $rule );
-		}
+	final protected function __construct() {
 	}
 
 	/**
 	 * Retrieves a factory set up for creating WP_Typography instances.
 	 *
 	 * @since 5.6.0 Parameter $full_plugin_path removed.
+	 * @since 5.8.0 Now throws an Object_Factory_Exception in case of error.
 	 *
 	 * @return WP_Typography_Factory
+	 *
+	 * @throws Object_Factory_Exception An exception is thrown if the factory cannot
+	 *                                  be created.
 	 */
 	public static function get() {
 		if ( ! isset( self::$factory ) ) {
 
 			// Create factory.
-			self::$factory = new static();
+			$factory = new static();
+			$factory = $factory->addRules( $factory->get_rules() );
+
+			if ( $factory instanceof WP_Typography_Factory ) {
+				self::$factory = $factory;
+			} else {
+				throw new Object_Factory_Exception( 'Could not create object factory.' ); // @codeCoverageIgnore
+			}
 		}
 
 		return self::$factory;
@@ -107,7 +117,7 @@ class WP_Typography_Factory extends Dice {
 			// API implementation.
 			'substitutions'                        => [
 				\WP_Typography::class => [
-					'instance' => \WP_Typography\Implementation::class,
+					self::INSTANCE => \WP_Typography\Implementation::class,
 				],
 			],
 			\WP_Typography\Implementation::class   => [
@@ -255,13 +265,13 @@ class WP_Typography_Factory extends Dice {
 	 */
 	protected function get_components() {
 		return [
-			[ 'instance' => Components\Setup::class ],
-			[ 'instance' => Components\Common::class ],
-			[ 'instance' => Components\Public_Interface::class ],
-			[ 'instance' => Components\Admin_Interface::class ],
-			[ 'instance' => Components\Multilingual_Support::class ],
-			[ 'instance' => Components\Block_Editor::class ],
-			[ 'instance' => Components\REST_API::class ],
+			[ self::INSTANCE => Components\Setup::class ],
+			[ self::INSTANCE => Components\Common::class ],
+			[ self::INSTANCE => Components\Public_Interface::class ],
+			[ self::INSTANCE => Components\Admin_Interface::class ],
+			[ self::INSTANCE => Components\Multilingual_Support::class ],
+			[ self::INSTANCE => Components\Block_Editor::class ],
+			[ self::INSTANCE => Components\REST_API::class ],
 		];
 	}
 
@@ -280,8 +290,8 @@ class WP_Typography_Factory extends Dice {
 	 */
 	protected function get_plugin_integrations() {
 		return [
-			[ 'instance' => Integration\ACF_Integration::class ],
-			[ 'instance' => Integration\WooCommerce_Integration::class ],
+			[ self::INSTANCE => Integration\ACF_Integration::class ],
+			[ self::INSTANCE => Integration\WooCommerce_Integration::class ],
 		];
 	}
 
@@ -300,13 +310,13 @@ class WP_Typography_Factory extends Dice {
 	 */
 	protected function get_supported_locales() {
 		return [
-			[ 'instance' => '$LocaleSwitzerland' ],
-			[ 'instance' => '$LocaleUnitedStates' ],
-			[ 'instance' => '$LocaleUnitedKingdom' ],
-			[ 'instance' => '$LocaleGerman' ],
-			[ 'instance' => '$LocaleFrench' ],
-			[ 'instance' => '$LocaleDutch' ],
-			[ 'instance' => '$LocaleSinoJapanese' ],
+			[ self::INSTANCE => '$LocaleSwitzerland' ],
+			[ self::INSTANCE => '$LocaleUnitedStates' ],
+			[ self::INSTANCE => '$LocaleUnitedKingdom' ],
+			[ self::INSTANCE => '$LocaleGerman' ],
+			[ self::INSTANCE => '$LocaleFrench' ],
+			[ self::INSTANCE => '$LocaleDutch' ],
+			[ self::INSTANCE => '$LocaleSinoJapanese' ],
 		];
 	}
 }

--- a/includes/wp-typography/exceptions/class-object-factory-exception.php
+++ b/includes/wp-typography/exceptions/class-object-factory-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of wp-Typography.
+ *
+ * Copyright 2021 Peter Putzer.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * ***
+ *
+ * @package mundschenk-at/wp-typography
+ * @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WP_Typography\Exceptions;
+
+/**
+ * An exception indicating that an error occured while setting up the object factory.
+ *
+ * @since 5.8.0
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ */
+class Object_Factory_Exception extends \RuntimeException {
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,9 @@
     * See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml
 	</description>
 
+	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="testVersion" value="7.0-"/>
+
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 		<exclude name="WordPress.Arrays.CommaAfterArrayItem.SpaceAfterComma" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit
 	bootstrap="tests/bootstrap.php"
 	beStrictAboutTestsThatDoNotTestAnything="true"
-	beStrictAboutCoversAnnotation="true"
+	beStrictAboutCoversAnnotation="false"
 	stopOnRisky="true"
 	verbose="true"
 >
@@ -12,7 +12,7 @@
 	    </testsuite>
 	</testsuites>
 	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
+		<whitelist processUncoveredFilesFromWhitelist="false" addUncoveredFilesFromWhitelist="false">
 	    	<directory suffix=".php">includes</directory>
 	    	<exclude>
 	    		<file>includes/_language_names.php</file>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pputzer, kingjeffrey
 Tags: typography, hyphenation, smart quotes, formatting, widows, orphans, typogrify, quotes, prettify, small caps, diacritics
 Requires at least: 4.9
-Requires PHP: 5.6
+Requires PHP: 7.0
 Tested up to: 5.5
 Stable tag: 5.7.2
 
@@ -40,7 +40,7 @@ Improve your web typography with:
 
 wp-Typography has the following requirements:
 
-* The host server must run PHP 5.6.0 or later,
+* The host server must run PHP 7.0.0 or later,
 * your installation of PHP must include the following PHP extensions (most do):
   - [mbstring](https://www.php.net/manual/en/mbstring.installation.php),
   - [DOM](https://www.php.net/manual/en/dom.installation.php), and

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,3 +51,28 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
 	define( 'MINUTE_IN_SECONDS', 60 );
 }
+
+// Other WordPress constants.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', 'wordpress/path/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! defined( 'ARRAY_N' ) ) {
+	define( 'ARRAY_N', 'ARRAY_N' );
+}
+if ( ! defined( 'OBJECT' ) ) {
+	define( 'OBJECT', 'OBJECT' );
+}
+if ( ! defined( 'OBJECT_K' ) ) {
+	define( 'OBJECT_K', 'OBJECT_K' );
+}
+
+// wp-Typography constants.
+if ( ! defined( 'WP_TYPOGRAPHY_PLUGIN_FILE' ) ) {
+	define( 'WP_TYPOGRAPHY_PLUGIN_FILE', 'plugin/file' );
+}
+if ( ! defined( 'WP_TYPOGRAPHY_PLUGIN_PATH' ) ) {
+	define( 'WP_TYPOGRAPHY_PLUGIN_PATH', 'plugin' );
+}

--- a/wp-typography.php
+++ b/wp-typography.php
@@ -29,7 +29,7 @@
  *  Description: Improve your web typography with: hyphenation, space control, intelligent character replacement, and CSS hooks.
  *  Author: Peter Putzer
  *  Author URI: https://code.mundschenk.at
- *  Version: 5.7.2
+ *  Version: 5.8.0-alpha.1
  *  License: GNU General Public License v2 or later
  *  License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *  Text Domain: wp-typography


### PR DESCRIPTION
Fixes #292, #109.

Changes proposed in this pull request:
- Updates `Dice\Dice` to `4.0.2` with custom patches for backwards compatibility with PHP 7.x.
- Bumps plugin version to `5.8.0-alpha.1`.
- Bumps PHP requirements to at least 7.0.
- Works around Xdebug issue by changing PHPunit configuration.
