### PR TITLE
Add preliminary support for PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-
+env:
+  MAIN_PHP_VERSION: '8.3'
 jobs:
   unit-tests:
     name: Unit tests (PHP ${{ matrix.php-versions }})
@@ -53,12 +54,10 @@ jobs:
         run: composer test
 
   coverage:
-    name: Coverage & SonarCloud (PHP ${{ matrix.php-versions }})
+    name: Coverage & SonarCloud
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
-      matrix:
-        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -68,7 +67,7 @@ jobs:
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ env.MAIN_PHP_VERSION }}
           coverage: xdebug
       - name: Remove unused Composer dependencies
         run: composer remove humbug/php-scoper sirbrillig/phpcs-import-detection szepeviktor/phpstan-wordpress --dev --no-interaction --no-update
@@ -110,15 +109,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
-      matrix:
-        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ env.MAIN_PHP_VERSION }}
           coverage: none
           extensions: gd
           tools: cs2pr
@@ -143,15 +140,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
-      matrix:
-        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ env.MAIN_PHP_VERSION }}
           coverage: none
           extensions: gd
       - name: Remove unused Composer dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
         experimental: [false]
         include:
-          - php-versions: '8.3'
+          - php-versions: '8.4'
             experimental: true
     steps:
       - name: Checkout repository
@@ -35,6 +35,9 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
       - name: Remove unused Composer dependencies
         run: composer remove humbug/php-scoper sirbrillig/phpcs-import-detection szepeviktor/phpstan-wordpress --dev --no-interaction --no-update
+      - name: Remove PHP 8.4 workaround dependency
+        if: ${{ matrix.php-versions < '8.2' }}
+        run: composer remove shish/safe --dev --no-interaction --no-update
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -55,7 +58,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -108,7 +111,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -141,7 +144,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "phpstan/extension-installer": "^1.2",
         "paulthewalton/acf-stubs": "^5.8",
         "phpstan/phpstan-phpunit": "^2",
-        "phpstan/phpstan-mockery": "^2.0"
+        "phpstan/phpstan-mockery": "^2.0",
+        "shish/safe": "^2"
     },
 
     "minimum-stability": "dev",

--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -141,7 +141,7 @@ abstract class WP_Typography {
 	 *
 	 * @return string The processed $text.
 	 */
-	public static function filter( string $text, Settings $settings = null ): string {
+	public static function filter( string $text, ?Settings $settings = null ): string {
 		return self::get_instance()->process( $text, false, false, $settings );
 	}
 
@@ -157,7 +157,7 @@ abstract class WP_Typography {
 	 *
 	 * @return string The processed $text.
 	 */
-	public static function filter_title( string $text, Settings $settings = null ): string {
+	public static function filter_title( string $text, ?Settings $settings = null ): string {
 		return self::get_instance()->process_title( $text, $settings );
 	}
 
@@ -173,7 +173,7 @@ abstract class WP_Typography {
 	 *
 	 * @return string[]
 	 */
-	public static function filter_title_parts( array $title_parts, Settings $settings = null ): array {
+	public static function filter_title_parts( array $title_parts, ?Settings $settings = null ): array {
 		return self::get_instance()->process_title_parts( $title_parts, $settings );
 	}
 
@@ -189,7 +189,7 @@ abstract class WP_Typography {
 	 *
 	 * @return string The processed $text.
 	 */
-	public static function filter_feed( string $text, Settings $settings = null ): string {
+	public static function filter_feed( string $text, ?Settings $settings = null ): string {
 		return self::get_instance()->process_feed( $text, false, $settings );
 	}
 
@@ -205,7 +205,7 @@ abstract class WP_Typography {
 	 *
 	 * @return string The processed $text.
 	 */
-	public static function filter_feed_title( string $text, Settings $settings = null ): string {
+	public static function filter_feed_title( string $text, ?Settings $settings = null ): string {
 		return self::get_instance()->process_feed_title( $text, $settings );
 	}
 

--- a/includes/wp-typography/class-implementation.php
+++ b/includes/wp-typography/class-implementation.php
@@ -321,7 +321,7 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string                 The processed `$text`.
 	 */
-	public function process_title( $text, Settings $settings = null ): string {
+	public function process_title( $text, ?Settings $settings = null ): string {
 		return $this->process( $text, true, false, $settings );
 	}
 
@@ -337,7 +337,7 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string                 The processed `$text`.
 	 */
-	public function process_feed_title( $text, Settings $settings = null ): string {
+	public function process_feed_title( $text, ?Settings $settings = null ): string {
 		return $this->process_feed( $text, true, $settings );
 	}
 
@@ -356,7 +356,7 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string                 The processed `$text`.
 	 */
-	public function process_feed( $text, $is_title = false, Settings $settings = null ): string {
+	public function process_feed( $text, $is_title = false, ?Settings $settings = null ): string {
 		return $this->process( $text, $is_title, true, $settings );
 	}
 
@@ -372,7 +372,7 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string[]
 	 */
-	public function process_title_parts( array $title_parts, Settings $settings = null ): array {
+	public function process_title_parts( array $title_parts, ?Settings $settings = null ): array {
 		foreach ( $title_parts as $index => $part ) {
 			// Remove "&shy;" and "&#8203;" after processing title part.
 			$title_parts[ $index ] = \wp_strip_all_tags(
@@ -397,7 +397,7 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string                   The processed `$text`.
 	 */
-	public function process( $text, $is_title = false, $force_feed = false, Settings $settings = null ): string {
+	public function process( $text, $is_title = false, $force_feed = false, ?Settings $settings = null ): string {
 		// Check if processing is disabled for this post.
 		$post_id = \get_the_ID();
 		$disable = ! empty( $post_id ) && \get_post_meta( $post_id, REST_API::WP_TYPOGRAPHY_DISABLED_META_KEY, true );

--- a/includes/wp-typography/components/class-multilingual-support.php
+++ b/includes/wp-typography/components/class-multilingual-support.php
@@ -253,7 +253,7 @@ class Multilingual_Support implements Plugin_Component {
 	 * @param  string               $locale     A locale (e.g. 'en-US').
 	 * @param  Locale_Settings|null $adjustment Locale-specific settings.
 	 */
-	protected function adjust_french_punctuation_spacing( Settings $settings, $locale, Locale_Settings $adjustment = null ): void {
+	protected function adjust_french_punctuation_spacing( Settings $settings, $locale, ?Locale_Settings $adjustment = null ): void {
 
 		if ( null === $adjustment ) {
 			$french_spacing = false;
@@ -277,7 +277,7 @@ class Multilingual_Support implements Plugin_Component {
 	 * @param  string               $locale     A locale (e.g. 'en-US').
 	 * @param  Locale_Settings|null $adjustment Locale-specific settings.
 	 */
-	protected function adjust_dash_style( Settings $settings, $locale, Locale_Settings $adjustment = null ): void {
+	protected function adjust_dash_style( Settings $settings, $locale, ?Locale_Settings $adjustment = null ): void {
 
 		if ( null === $adjustment ) {
 			$dash_style = $settings->dash_style();
@@ -305,7 +305,7 @@ class Multilingual_Support implements Plugin_Component {
 	 * @param  string               $locale     A locale (e.g. 'en-US').
 	 * @param  Locale_Settings|null $adjustment Locale-specific settings.
 	 */
-	protected function adjust_quote_styles( Settings $settings, $locale, Locale_Settings $adjustment = null ): void {
+	protected function adjust_quote_styles( Settings $settings, $locale, ?Locale_Settings $adjustment = null ): void {
 
 		if ( null === $adjustment ) {
 			$primary   = $settings->primary_quote_style();

--- a/includes/wp-typography/typography/class-custom-token-fix.php
+++ b/includes/wp-typography/typography/class-custom-token-fix.php
@@ -82,7 +82,7 @@ class Custom_Token_Fix extends Abstract_Token_Fix {
 	 *
 	 * @return Token[] An array of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ): array {
+	public function apply( array $tokens, Settings $settings, $is_title = false, ?\DOMText $textnode = null ): array {
 
 		/**
 		 * Filters the tokenized text node content (limited to a certain "word" type).


### PR DESCRIPTION
Changes proposed in this pull request:
- Runs CI tasks on PHP 8.3, experimental on PHP 8.4.
- Fixes build task to work on PHP 8.4.
- Fixes PHP 8.4 code deprecations (but not yet in `php-typography`).
