### PR TITLE
Don't print styles when STYLE_CSS_INCLUDE is disabled

### DIFF
--- a/includes/wp-typography/components/class-public-interface.php
+++ b/includes/wp-typography/components/class-public-interface.php
@@ -243,14 +243,16 @@ class Public_Interface implements Plugin_Component {
 	 */
 	public function enqueue_styles(): void {
 		// Custom styles set via the CSS Hooks settings page.
-		$custom_styles = \trim( (string) $this->config[ Config::STYLE_CSS ] );
-		if ( ! empty( $custom_styles ) ) {
-			// Register and enqueue dummy stylesheet.
-			\wp_register_style( 'wp-typography-custom', '' ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- only inline.
-			\wp_enqueue_style( 'wp-typography-custom' );
+		if ( $this->config[ Config::STYLE_CSS_INCLUDE ] ) {
+			$custom_styles = \trim( (string) $this->config[ Config::STYLE_CSS ] );
+			if ( ! empty( $custom_styles ) ) {
+				// Register and enqueue dummy stylesheet.
+				\wp_register_style( 'wp-typography-custom', '' ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- only inline.
+				\wp_enqueue_style( 'wp-typography-custom' );
 
-			// Print the inline styles.
-			\wp_add_inline_style( 'wp-typography-custom', $this->clean_styles( $custom_styles ) );
+				// Print the inline styles.
+				\wp_add_inline_style( 'wp-typography-custom', $this->clean_styles( $custom_styles ) );
+			}
 		}
 
 		// The Safari bug workaround.

--- a/tests/components/class-public-interface-test.php
+++ b/tests/components/class-public-interface-test.php
@@ -302,7 +302,7 @@ class Public_Interface_Test extends TestCase {
 			]
 		);
 
-		Functions\expect( 'wp_register_style' )->once()->with( 'wp-typography-custom', false );
+		Functions\expect( 'wp_register_style' )->once()->with( 'wp-typography-custom', '' );
 		Functions\expect( 'wp_enqueue_style' )->once()->with( 'wp-typography-custom' );
 
 		$this->public_if->shouldReceive( 'clean_styles' )->once()->with( $custom_style )->andReturn( $clean_style );
@@ -311,6 +311,32 @@ class Public_Interface_Test extends TestCase {
 
 		$this->public_if->enqueue_styles();
 	}
+
+	/**
+	 * Test enqueue_styles.
+	 *
+	 * @covers ::enqueue_styles
+	 */
+	public function test_enqueue_styles_css_disabled(): void {
+		$custom_style = 'my: css;';
+		$this->prepareOptions(
+			[
+				Config::STYLE_CSS_INCLUDE                => false,
+				Config::STYLE_CSS                        => $custom_style,
+				Config::HYPHENATE_SAFARI_FONT_WORKAROUND => false,
+			]
+		);
+
+		Functions\expect( 'wp_register_style' )->never();
+		Functions\expect( 'wp_enqueue_style' )->never();
+
+		$this->public_if->shouldReceive( 'clean_styles' )->never();
+
+		Functions\expect( 'wp_add_inline_style' )->never();
+
+		$this->public_if->enqueue_styles();
+	}
+
 
 	/**
 	 * Test enqueue_styles.


### PR DESCRIPTION
Fixes #315.

Changes proposed in this pull request:
- Don't print styles when `STYLE_CSS_INCLUDE` is false.
