### PR TITLE
Ensure i18n functions are called during 'init' at the earliest

### DIFF
--- a/includes/class-wp-typography.php
+++ b/includes/class-wp-typography.php
@@ -50,8 +50,8 @@ use PHP_Typography\Settings;
  * @method string process_feed($text, $is_title = false, Settings $settings = null) Processes a content text fragment as part of an RSS feed.
  * @method string[] process_title_parts($title_parts, Settings $settings = null) Processes title parts and strips &shy; and zero-width space.
  *
- * @method array<string,string> get_hyphenation_languages() Retrieves and caches the list of valid hyphenation languages.
- * @method array<string,string> get_diacritic_languages() Retrieves and caches the list of valid diacritic replacement languages.
+ * @method array<string,string> get_hyphenation_languages( $translate = true ) Retrieves and caches the list of valid hyphenation languages.
+ * @method array<string,string> get_diacritic_languages( $translate = true ) Retrieves and caches the list of valid diacritic replacement languages.
  */
 abstract class WP_Typography {
 

--- a/includes/wp-typography/class-implementation.php
+++ b/includes/wp-typography/class-implementation.php
@@ -155,30 +155,80 @@ class Implementation extends \WP_Typography {
 	 * Retrieves and caches the list of valid hyphenation languages.
 	 *
 	 * @since 4.0.0
-	 * @since 5.0.0 Language names are translated.
-	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 * @since 5.0.0  Language names are translated.
+	 * @since 5.3.0  The method can be called both statically and dynamically.
+	 * @since 5.10.0 Optional parameter `$translate` added.
+	 *
+	 * @param  bool $translate Optional. Determines whether language names will be translated. Default true.
 	 *
 	 * @return string[] An array in the form of ( $language_code => $language ).
 	 */
-	public function get_hyphenation_languages(): array {
-		return $this->load_languages( 'hyphenate_languages', [ PHP_Typography::class, 'get_hyphenation_languages' ], 'hyphenate' );
+	public function get_hyphenation_languages( bool $translate = true ): array {
+		return $this->load_languages( 'hyphenate_languages', [ PHP_Typography::class, 'get_hyphenation_languages' ], 'hyphenate', $translate );
 	}
 
 	/**
 	 * Retrieves and caches the list of valid diacritic replacement languages.
 	 *
 	 * @since 4.0.0
-	 * @since 5.0.0 Language names are translated.
-	 * @since 5.3.0 The method can be called both statically and dynamically.
+	 * @since 5.0.0  Language names are translated.
+	 * @since 5.3.0  The method can be called both statically and dynamically.
+	 * @since 5.10.0 Optional parameter `$translate` added.
+	 *
+	 * @param  bool $translate Optional. Determines whether language names will be translated. Default true.
 	 *
 	 * @return string[] An array in the form of ( $language_code => $language ).
 	 */
-	public function get_diacritic_languages(): array {
-		return $this->load_languages( 'diacritic_languages', [ PHP_Typography::class, 'get_diacritic_languages' ], 'diacritic' );
+	public function get_diacritic_languages( bool $translate = true ): array {
+		return $this->load_languages( 'diacritic_languages', [ PHP_Typography::class, 'get_diacritic_languages' ], 'diacritic', $translate );
 	}
 
 	/**
 	 * Load and cache given language list.
+	 *
+	 * @since 5.10.0 Optional parameter `$translate` added.
+	 *
+	 * @param  string   $cache_key         A cache key.
+	 * @param  callable $get_language_list Retrieval function for the language list.
+	 * @param  string   $type              Either 'diacritic' or 'hyphenate'.
+	 * @param  bool     $translate         Optional. Determines whether language names need to be translated. Default true.
+	 *
+	 * @return string[]
+	 */
+	protected function load_languages( string $cache_key, callable $get_language_list, string $type, bool $translate = true ): array {
+		if ( $translate ) {
+			// Try to load hyphenation language list from cache.
+			$languages = $this->cache->get( $cache_key, $found );
+
+			// Dynamically generate the list of hyphenation language patterns.
+			if ( false === $found || ! \is_array( $languages ) ) {
+				$languages = $this->translate_languages( $this->maybe_load_untranslated_languages_from_disk( $cache_key, $get_language_list, $type ) );
+
+				/**
+				 * Filters the caching duration for the language plugin lists.
+				 *
+				 * @since 3.2.0
+				 * @since 5.9.0 Type of parameter `$duration` corrected to `int`.
+				 *
+				 * @param int    $duration The duration in seconds. Defaults to 1 week.
+				 * @param string $list     The name language plugin list.
+				 */
+				$duration = \apply_filters( 'typo_language_list_caching_duration', WEEK_IN_SECONDS, "{$type}_languages" );
+
+				// Cache translated hyphenation languages.
+				$this->cache->set( $cache_key, $languages, $duration );
+			}
+		} else {
+			$languages = $this->maybe_load_untranslated_languages_from_disk( $cache_key, $get_language_list, $type );
+		}
+
+		return $languages;
+	}
+
+	/**
+	 * Load given language list from disk without translating the language names.
+	 *
+	 * @since 5.10.0
 	 *
 	 * @param  string   $cache_key         A cache key.
 	 * @param  callable $get_language_list Retrieval function for the language list.
@@ -186,27 +236,20 @@ class Implementation extends \WP_Typography {
 	 *
 	 * @return string[]
 	 */
-	protected function load_languages( $cache_key, callable $get_language_list, $type ): array {
-		// Try to load hyphenation language list from cache.
-		$languages = $this->cache->get( $cache_key, $found );
+	protected function maybe_load_untranslated_languages_from_disk( string $cache_key, callable $get_language_list, string $type ): array {
+		// Try to load language list from cache.
+		$cache_key_raw = "${cache_key}_raw";
+		$languages     = $this->cache->get( $cache_key_raw, $found );
 
 		// Dynamically generate the list of hyphenation language patterns.
 		if ( false === $found || ! \is_array( $languages ) ) {
-			$languages = self::translate_languages( $get_language_list() );
+			/** This filter is documented in wp-typography/components/class-multilingual-support.php */
+			$duration = \apply_filters( 'typo_language_list_caching_duration', WEEK_IN_SECONDS, "raw_{$type}_languages" );
 
-			/**
-			 * Filters the caching duration for the language plugin lists.
-			 *
-			 * @since 3.2.0
-			 * @since 5.9.0 Type of parameter `$duration` corrected to `int`.
-			 *
-			 * @param int    $duration The duration in seconds. Defaults to 1 week.
-			 * @param string $list     The name language plugin list.
-			 */
-			$duration = \apply_filters( 'typo_language_list_caching_duration', WEEK_IN_SECONDS, "{$type}_languages" );
+			$languages = $get_language_list();
 
 			// Cache translated hyphenation languages.
-			$this->cache->set( $cache_key, $languages, $duration );
+			$this->cache->set( $cache_key_raw, $languages, $duration );
 		}
 
 		return $languages;
@@ -215,11 +258,13 @@ class Implementation extends \WP_Typography {
 	/**
 	 * Translate language list.
 	 *
+	 * @since 5.10.0 Changed into a protected method for easier unit testing.
+	 *
 	 * @param string[] $languages An array in the form [ LANGUAGE_CODE => LANGUAGE ].
 	 *
 	 * @return string[] The same array with the language name translated.
 	 */
-	private static function translate_languages( array $languages ): array {
+	protected function translate_languages( array $languages ): array {
 		\array_walk(
 			$languages,
 			function ( &$lang ) {

--- a/includes/wp-typography/components/class-admin-interface.php
+++ b/includes/wp-typography/components/class-admin-interface.php
@@ -187,21 +187,11 @@ class Admin_Interface implements Plugin_Component {
 	 */
 	public function run(): void {
 		if ( \is_admin() ) {
-
 			// Cache the plugin basename.
 			$this->plugin_basename = \plugin_basename( \WP_TYPOGRAPHY_PLUGIN_FILE );
 
-			// Set up default options.
-			$this->defaults = Plugin_Configuration::get_defaults();
-
-			// Initialize admin form.
-			$this->admin_resource_links = $this->initialize_resource_links();
-			$this->admin_help_pages     = $this->initialize_help_pages();
-			$this->admin_form_tabs      = UI\Tabs::get_tabs();
-			$this->admin_form_sections  = UI\Sections::get_sections();
-			$this->admin_form_controls  = Control_Factory::initialize( $this->defaults, $this->options, Options::CONFIGURATION );
-
 			// Add action hooks.
+			\add_action( 'init', [ $this, 'initialize_translated_properties' ] );
 			\add_action( 'admin_menu', [ $this, 'add_options_page' ] );
 			\add_action( 'admin_init', [ $this, 'register_the_settings' ] );
 			\add_action( 'admin_init', [ $this, 'maybe_add_privacy_notice_content' ] );
@@ -209,6 +199,24 @@ class Admin_Interface implements Plugin_Component {
 			// Add filter hooks.
 			\add_filter( 'plugin_action_links_' . $this->plugin_basename, [ $this, 'plugin_action_links' ] );
 		}
+	}
+
+	/**
+	 * Initializes all properties containign translated strings, as the
+	 * WordPress i18n functions cannot be called before `init`.
+	 *
+	 * @since 5.10.0
+	 */
+	public function initialize_translated_properties(): void {
+		// Set up default options.
+		$this->defaults = Plugin_Configuration::get_defaults();
+
+		// Initialize admin form.
+		$this->admin_resource_links = $this->initialize_resource_links();
+		$this->admin_help_pages     = $this->initialize_help_pages();
+		$this->admin_form_tabs      = UI\Tabs::get_tabs();
+		$this->admin_form_sections  = UI\Sections::get_sections();
+		$this->admin_form_controls  = Control_Factory::initialize( $this->defaults, $this->options, Options::CONFIGURATION );
 	}
 
 	/**

--- a/includes/wp-typography/components/class-multilingual-support.php
+++ b/includes/wp-typography/components/class-multilingual-support.php
@@ -129,8 +129,8 @@ class Multilingual_Support implements Plugin_Component {
 	 */
 	public function add_plugin_defaults_filter(): void {
 		// Translation of language names is irrelevant here.
-		$this->hyphenation_languages = $this->api->get_hyphenation_languages();
-		$this->diacritic_languages   = $this->api->get_diacritic_languages();
+		$this->hyphenation_languages = $this->api->get_hyphenation_languages( false );
+		$this->diacritic_languages   = $this->api->get_diacritic_languages( false );
 
 		// Filter the defaults.
 		\add_filter( 'typo_plugin_defaults', [ $this, 'filter_defaults' ] );

--- a/tests/components/class-multilingual-support-test.php
+++ b/tests/components/class-multilingual-support-test.php
@@ -180,8 +180,8 @@ class Multilingual_Support_Test extends TestCase {
 	 */
 	public function test_add_plugin_defaults_filter(): void {
 
-		$this->api->shouldReceive( 'get_hyphenation_languages' )->once()->andReturn( [ 'de' => 'Deutsch' ] );
-		$this->api->shouldReceive( 'get_diacritic_languages' )->once()->andReturn( [ 'en' => 'English' ] );
+		$this->api->shouldReceive( 'get_hyphenation_languages' )->once()->with( false )->andReturn( [ 'de' => 'Deutsch' ] );
+		$this->api->shouldReceive( 'get_diacritic_languages' )->once()->with( false )->andReturn( [ 'en' => 'English' ] );
 
 		Filters\expectAdded( 'typo_plugin_defaults' )->once()->with( [ $this->multi, 'filter_defaults' ] );
 


### PR DESCRIPTION
Fixes #326.

Changes proposed in this pull request:
- Moves all function calls accessing translated strings to the `init` hook.
- Caches untranslated language names separately for use in multilingual support.